### PR TITLE
feat: GitHub・Clineエージェント実装

### DIFF
--- a/CLINE.md
+++ b/CLINE.md
@@ -1,0 +1,237 @@
+# 01_project-overview.md
+
+# プロジェクト概要
+
+**必ず日本語で対応すること**
+
+このファイルは、このリポジトリでコードを扱う際に Claude Code (claude.ai/code) にガイダンスを提供します。
+
+## プロジェクト概要
+
+このリポジトリは、複数の AI コーディングエージェント用の context ファイルを統一設定から自動生成する Rust 製コマンドラインツールです。
+
+### 目的
+
+- GitHub Copilot、Cline、Cursor、Claude Code 用の context ファイルを一元管理
+- 一つの設定ファイルから各ツール固有のファイル形式を自動生成
+- 開発チーム間での AI ツール設定の一貫性を保つ
+- Rust による高速・安全な実装
+
+### サポート対象ツール
+
+1. **🎯 Cursor**: `.cursor/rules/*.mdc` ファイル（実装済み）
+2. **🚧 Cline**: `.clinerules/*.md` ファイル（今後実装予定）
+3. **🚧 GitHub Copilot**: `instructions.md` 階層配置（今後実装予定）
+4. **🚧 Claude Code**: `CLAUDE.md`（今後実装予定）
+
+詳細な設計概要は `docs/concept.md` を参照してください。
+
+# 02_architecture.md
+
+# アーキテクチャノート
+
+## 設計原則
+
+- **型安全性**: Rust の型システムによるコンパイル時エラー検出
+- **メモリ安全性**: 所有権システムによる安全なメモリ管理
+- **並行処理**: Tokio による効率的な非同期処理
+- **抽象化**: トレイトベースのエージェント設計
+- **統一管理**: 共通の設定ファイルから各ツール用ファイルを生成
+
+## プロジェクト構造
+
+```
+src/
+├── main.rs                 # CLI エントリーポイント
+├── lib.rs                  # ライブラリエントリーポイント
+├── config/                 # 設定管理
+│   ├── mod.rs
+│   ├── loader.rs           # 設定読み込み
+│   └── error.rs            # 設定エラー型
+├── core/                   # コア機能
+│   ├── mod.rs
+│   └── markdown_merger.rs  # Markdownファイル結合
+├── agents/                 # エージェント実装
+│   ├── mod.rs
+│   ├── base.rs            # ベースユーティリティ
+│   └── cursor.rs          # Cursor実装
+└── types/                  # 型定義
+    ├── mod.rs
+    ├── config.rs          # 設定型
+    └── agent.rs           # エージェント型
+
+docs/                      # 設計ドキュメント
+├── concept.md             # 設計概要
+├── design_doc.md          # 技術仕様書（Rust版）
+└── requirements.md        # 要件定義
+
+target/                    # ビルド出力
+├── debug/                 # デバッグビルド
+└── release/               # リリースビルド
+
+Cargo.toml                 # プロジェクト設定
+Cargo.lock                 # 依存関係ロック
+```
+
+## 実装時の注意点
+
+- 新しい機能を追加する際は、対応するテストも同時作成
+- テストファイルは `#[cfg(test)]` モジュールまたは `tests/` ディレクトリを使用
+- エラーハンドリング（`Result<T, E>`）も含めてテストケースを作成
+- 非同期処理は `#[tokio::test]` を使用してテスト
+
+## 型システムの活用
+
+- `serde` による設定ファイルの型安全なデシリアライゼーション
+- `async-trait` による非同期トレイトの実装
+- `thiserror` による構造化されたエラー型定義
+- オプション型（`Option<T>`）による明示的な Null 安全性
+
+## パフォーマンス特徴
+
+- **高速起動**: ネイティブバイナリによる瞬時起動（100ms 以内）
+- **低メモリ**: 効率的なメモリ管理（10MB 以下）
+- **並列処理**: 非同期 I/O による高速ファイル処理
+- **ゼロコピー**: 不要な文字列コピーの回避
+
+# 03_dependencies.md
+
+# 依存関係
+
+## 主要なクレート
+
+- **clap**: CLI 構築フレームワーク（derive API 使用）
+- **tokio**: 非同期ランタイム
+- **serde + serde_yaml**: 設定ファイル処理
+- **anyhow + thiserror**: エラーハンドリング
+- **async-trait**: 非同期トレイト
+- **path-clean**: パス正規化
+
+## 開発用クレート
+
+- **tokio-test**: 非同期テスト
+- **tempfile**: テスト用一時ファイル
+
+# 04_development-rules.md
+
+# 開発ルール
+
+## テスト要件
+
+- **必須**: 各モジュールは Rust 標準テストフレームワークでテストを作成すること
+- **カバレッジ**: 主要な機能とエラーパスのテストを含めること
+- **作業完了**: 作業終了時は必ずテストが通ることを確認すること
+
+## テスト実行例
+
+```bash
+# 全テスト実行
+cargo test
+
+# 特定のテストモジュール実行
+cargo test config
+cargo test agents::cursor
+
+# テストカバレッジ（tarpaulin要インストール）
+cargo install cargo-tarpaulin
+cargo tarpaulin --out html
+
+# 統合テスト実行
+cargo test --test integration_test
+```
+
+## Git 運用
+
+- 開発作業については、ブランチを分けて作業すること
+- 指示された内容は、まず ai-works ディレクトリ内に作業要件を整理すること
+- 作業完了後は、gh コマンドで PR を作成すること
+
+## コード品質
+
+- **rustfmt**: 統一されたコードフォーマット
+- **clippy**: 高品質な Rust コードのためのリンター
+- **型安全性**: Rust の強力な型システムを活用
+- **エラーハンドリング**: anyhow・thiserror による適切なエラー処理
+
+## Lint & Format
+
+- 作業完了時に `cargo fmt` と `cargo clippy` を実行してください。
+
+## 作業記録の作成
+
+- 作業開始時に、`ai-works` ディレクトリに `yyyy-mm-dd-<work name>.md` を作成し、作業内容、要件をまとめてください
+- 指示された場合は、一度作業内容を指示者に確認してもらってから作業を進めてください
+
+# 05_development-setup.md
+
+# 開発環境セットアップ
+
+## 必要な環境
+
+- Rust 1.70.0 以上
+- Cargo（Rust と一緒にインストール）
+
+## 主要コマンド
+
+```bash
+# プロジェクトクローン
+git clone https://github.com/morooka-akira/ai-context-management
+cd ai-context-management
+
+# ビルド
+cargo build
+
+# リリースビルド
+cargo build --release
+
+# テスト実行
+cargo test
+
+# 開発版での実行
+cargo run -- init
+cargo run -- generate
+cargo run -- validate
+cargo run -- list-agents
+
+# リント・フォーマット
+cargo fmt     # コードフォーマット
+cargo clippy  # リント実行
+
+# ドキュメント生成
+cargo doc --open
+```
+
+# 06_roadmap.md
+
+# 今後の拡張予定
+
+## Phase 2 機能
+
+- Cline、GitHub Copilot、Claude Code エージェント実装
+- ウォッチモード（ファイル変更時の自動生成）
+- 設定継承機能
+
+## Phase 3 機能
+
+- プラグインシステム（WASM 対応）
+- Web UI
+- クラウド同期
+
+# 07_references.md
+
+# 参考リンク
+
+## 技術ドキュメント
+
+- [Rust 公式ドキュメント](https://doc.rust-lang.org/)
+- [Tokio 公式ドキュメント](https://tokio.rs/)
+- [clap 公式ドキュメント](https://docs.rs/clap/)
+- [serde 公式ドキュメント](https://serde.rs/)
+
+## AI ツール関連
+
+- [Claude Code Memory (CLAUDE.md)](https://docs.anthropic.com/en/docs/claude-code/memory)
+- [Cline Rules](https://docs.cline.bot/features/cline-rules)
+- [GitHub Copilot Custom Instructions](https://docs.github.com/en/copilot/customizing-copilot/adding-repository-custom-instructions-for-github-copilot)
+- [VS Code Copilot Customization](https://code.visualstudio.com/docs/copilot/copilot-customization#_use-instructionsmd-files)
+- [Cursor Rules](https://docs.cursor.com/context/rules)

--- a/GITHUB.md
+++ b/GITHUB.md
@@ -1,0 +1,237 @@
+# 01_project-overview.md
+
+# プロジェクト概要
+
+**必ず日本語で対応すること**
+
+このファイルは、このリポジトリでコードを扱う際に Claude Code (claude.ai/code) にガイダンスを提供します。
+
+## プロジェクト概要
+
+このリポジトリは、複数の AI コーディングエージェント用の context ファイルを統一設定から自動生成する Rust 製コマンドラインツールです。
+
+### 目的
+
+- GitHub Copilot、Cline、Cursor、Claude Code 用の context ファイルを一元管理
+- 一つの設定ファイルから各ツール固有のファイル形式を自動生成
+- 開発チーム間での AI ツール設定の一貫性を保つ
+- Rust による高速・安全な実装
+
+### サポート対象ツール
+
+1. **🎯 Cursor**: `.cursor/rules/*.mdc` ファイル（実装済み）
+2. **🚧 Cline**: `.clinerules/*.md` ファイル（今後実装予定）
+3. **🚧 GitHub Copilot**: `instructions.md` 階層配置（今後実装予定）
+4. **🚧 Claude Code**: `CLAUDE.md`（今後実装予定）
+
+詳細な設計概要は `docs/concept.md` を参照してください。
+
+# 02_architecture.md
+
+# アーキテクチャノート
+
+## 設計原則
+
+- **型安全性**: Rust の型システムによるコンパイル時エラー検出
+- **メモリ安全性**: 所有権システムによる安全なメモリ管理
+- **並行処理**: Tokio による効率的な非同期処理
+- **抽象化**: トレイトベースのエージェント設計
+- **統一管理**: 共通の設定ファイルから各ツール用ファイルを生成
+
+## プロジェクト構造
+
+```
+src/
+├── main.rs                 # CLI エントリーポイント
+├── lib.rs                  # ライブラリエントリーポイント
+├── config/                 # 設定管理
+│   ├── mod.rs
+│   ├── loader.rs           # 設定読み込み
+│   └── error.rs            # 設定エラー型
+├── core/                   # コア機能
+│   ├── mod.rs
+│   └── markdown_merger.rs  # Markdownファイル結合
+├── agents/                 # エージェント実装
+│   ├── mod.rs
+│   ├── base.rs            # ベースユーティリティ
+│   └── cursor.rs          # Cursor実装
+└── types/                  # 型定義
+    ├── mod.rs
+    ├── config.rs          # 設定型
+    └── agent.rs           # エージェント型
+
+docs/                      # 設計ドキュメント
+├── concept.md             # 設計概要
+├── design_doc.md          # 技術仕様書（Rust版）
+└── requirements.md        # 要件定義
+
+target/                    # ビルド出力
+├── debug/                 # デバッグビルド
+└── release/               # リリースビルド
+
+Cargo.toml                 # プロジェクト設定
+Cargo.lock                 # 依存関係ロック
+```
+
+## 実装時の注意点
+
+- 新しい機能を追加する際は、対応するテストも同時作成
+- テストファイルは `#[cfg(test)]` モジュールまたは `tests/` ディレクトリを使用
+- エラーハンドリング（`Result<T, E>`）も含めてテストケースを作成
+- 非同期処理は `#[tokio::test]` を使用してテスト
+
+## 型システムの活用
+
+- `serde` による設定ファイルの型安全なデシリアライゼーション
+- `async-trait` による非同期トレイトの実装
+- `thiserror` による構造化されたエラー型定義
+- オプション型（`Option<T>`）による明示的な Null 安全性
+
+## パフォーマンス特徴
+
+- **高速起動**: ネイティブバイナリによる瞬時起動（100ms 以内）
+- **低メモリ**: 効率的なメモリ管理（10MB 以下）
+- **並列処理**: 非同期 I/O による高速ファイル処理
+- **ゼロコピー**: 不要な文字列コピーの回避
+
+# 03_dependencies.md
+
+# 依存関係
+
+## 主要なクレート
+
+- **clap**: CLI 構築フレームワーク（derive API 使用）
+- **tokio**: 非同期ランタイム
+- **serde + serde_yaml**: 設定ファイル処理
+- **anyhow + thiserror**: エラーハンドリング
+- **async-trait**: 非同期トレイト
+- **path-clean**: パス正規化
+
+## 開発用クレート
+
+- **tokio-test**: 非同期テスト
+- **tempfile**: テスト用一時ファイル
+
+# 04_development-rules.md
+
+# 開発ルール
+
+## テスト要件
+
+- **必須**: 各モジュールは Rust 標準テストフレームワークでテストを作成すること
+- **カバレッジ**: 主要な機能とエラーパスのテストを含めること
+- **作業完了**: 作業終了時は必ずテストが通ることを確認すること
+
+## テスト実行例
+
+```bash
+# 全テスト実行
+cargo test
+
+# 特定のテストモジュール実行
+cargo test config
+cargo test agents::cursor
+
+# テストカバレッジ（tarpaulin要インストール）
+cargo install cargo-tarpaulin
+cargo tarpaulin --out html
+
+# 統合テスト実行
+cargo test --test integration_test
+```
+
+## Git 運用
+
+- 開発作業については、ブランチを分けて作業すること
+- 指示された内容は、まず ai-works ディレクトリ内に作業要件を整理すること
+- 作業完了後は、gh コマンドで PR を作成すること
+
+## コード品質
+
+- **rustfmt**: 統一されたコードフォーマット
+- **clippy**: 高品質な Rust コードのためのリンター
+- **型安全性**: Rust の強力な型システムを活用
+- **エラーハンドリング**: anyhow・thiserror による適切なエラー処理
+
+## Lint & Format
+
+- 作業完了時に `cargo fmt` と `cargo clippy` を実行してください。
+
+## 作業記録の作成
+
+- 作業開始時に、`ai-works` ディレクトリに `yyyy-mm-dd-<work name>.md` を作成し、作業内容、要件をまとめてください
+- 指示された場合は、一度作業内容を指示者に確認してもらってから作業を進めてください
+
+# 05_development-setup.md
+
+# 開発環境セットアップ
+
+## 必要な環境
+
+- Rust 1.70.0 以上
+- Cargo（Rust と一緒にインストール）
+
+## 主要コマンド
+
+```bash
+# プロジェクトクローン
+git clone https://github.com/morooka-akira/ai-context-management
+cd ai-context-management
+
+# ビルド
+cargo build
+
+# リリースビルド
+cargo build --release
+
+# テスト実行
+cargo test
+
+# 開発版での実行
+cargo run -- init
+cargo run -- generate
+cargo run -- validate
+cargo run -- list-agents
+
+# リント・フォーマット
+cargo fmt     # コードフォーマット
+cargo clippy  # リント実行
+
+# ドキュメント生成
+cargo doc --open
+```
+
+# 06_roadmap.md
+
+# 今後の拡張予定
+
+## Phase 2 機能
+
+- Cline、GitHub Copilot、Claude Code エージェント実装
+- ウォッチモード（ファイル変更時の自動生成）
+- 設定継承機能
+
+## Phase 3 機能
+
+- プラグインシステム（WASM 対応）
+- Web UI
+- クラウド同期
+
+# 07_references.md
+
+# 参考リンク
+
+## 技術ドキュメント
+
+- [Rust 公式ドキュメント](https://doc.rust-lang.org/)
+- [Tokio 公式ドキュメント](https://tokio.rs/)
+- [clap 公式ドキュメント](https://docs.rs/clap/)
+- [serde 公式ドキュメント](https://serde.rs/)
+
+## AI ツール関連
+
+- [Claude Code Memory (CLAUDE.md)](https://docs.anthropic.com/en/docs/claude-code/memory)
+- [Cline Rules](https://docs.cline.bot/features/cline-rules)
+- [GitHub Copilot Custom Instructions](https://docs.github.com/en/copilot/customizing-copilot/adding-repository-custom-instructions-for-github-copilot)
+- [VS Code Copilot Customization](https://code.visualstudio.com/docs/copilot/copilot-customization#_use-instructionsmd-files)
+- [Cursor Rules](https://docs.cursor.com/context/rules)

--- a/ai-context.yaml
+++ b/ai-context.yaml
@@ -3,6 +3,6 @@ output_mode: split
 base_docs_dir: ./ai-context
 agents:
   cursor: true
-  cline: false
-  github: false
+  cline: true
+  github: true
   claude: true

--- a/ai-works/2025-01-07-github-cline-agents-implementation.md
+++ b/ai-works/2025-01-07-github-cline-agents-implementation.md
@@ -1,0 +1,171 @@
+# GitHub・Cline エージェント実装作業記録
+
+## 📅 作業日
+
+2025-01-07
+
+## 🎯 作業目標
+
+GitHub と Cline エージェント用の設定ファイル出力機能を実装する
+
+## 📋 要件
+
+- **シンプル化原則に従う**: 余計な機能は実装しない
+- **既存の Cursor・Claude エージェントと一貫性**: 同じ抽象度で実装
+- **merged モードのみ**: Claude と同様に merged のみ対応
+- **出力先**: `GITHUB.md` および `CLINE.md` (プロジェクトルート)
+- **テスト作成**: 必須
+- **統合**: main.rs とモジュールシステムに統合
+
+## 🔍 既存実装の分析
+
+### Claude エージェントパターンの踏襲
+
+前回の Claude エージェント実装 (`2025-06-08-claude-agent-implementation.md`) と同じパターンで実装：
+
+- **シンプル**: merged モードのみ対応
+- **出力先**: プロジェクトルートに `.md` ファイル
+- **フォーマット**: 純粋な Markdown（frontmatter なし）
+- **一貫性**: 同じインターフェース（`new` + `generate`）
+
+### 設計方針
+
+- **GitHub エージェント**: `GITHUB.md` を出力
+- **Cline エージェント**: `CLINE.md` を出力
+- **共通設計**: Claude エージェントと完全に同じパターン
+
+## 📝 実装タスク
+
+### Phase 1: GitHub エージェント実装
+
+- [x] `src/agents/github.rs` を作成
+- [x] `GitHubAgent` 構造体と実装
+- [x] `generate()` メソッド（merged のみ）
+- [x] 7 つのテストケース作成（Claude と同様）
+
+### Phase 2: Cline エージェント実装
+
+- [x] `src/agents/cline.rs` を作成
+- [x] `ClineAgent` 構造体と実装
+- [x] `generate()` メソッド（merged のみ）
+- [x] 7 つのテストケース作成（Claude と同様）
+
+### Phase 3: 統合
+
+- [x] `src/agents/mod.rs` に GitHub・Cline エージェント追加
+- [x] `src/main.rs` の use 文追加
+- [x] `src/main.rs` の `generate_agent_files` に両エージェント追加
+
+### Phase 4: テスト・動作確認
+
+- [x] 単体テスト（全て通過）
+- [x] 個別エージェント実行確認
+- [x] 全エージェント同時実行確認
+- [x] コード品質チェック（cargo fmt + clippy）
+
+## 🚨 注意事項
+
+- **YAGNI 原則**: 今必要でない機能は実装しない
+- **テスト必須**: Claude エージェントと同じ 7 つのテストパターン
+- **コード品質**: rustfmt と clippy を実行
+- **一貫性**: 既存の Claude エージェントと完全に同じパターンを踏襲
+
+## 📈 期待される動作
+
+```bash
+# ai-context.yaml で github: true, cline: true にして
+aicm generate
+
+# または特定のエージェントのみ
+aicm generate --agent github
+aicm generate --agent cline
+```
+
+**出力**:
+
+- プロジェクトルートに `GITHUB.md` が生成される
+- プロジェクトルートに `CLINE.md` が生成される
+  **内容**: `ai-context/` 配下の全 `.md` ファイルを結合した純粋な Markdown
+
+---
+
+## ✅ 作業完了
+
+### 🎯 実装成果
+
+- **GitHub エージェント実装**: `src/agents/github.rs` を新規作成
+- **Cline エージェント実装**: `src/agents/cline.rs` を新規作成
+- **シンプル設計**: merged モードのみ、純粋な Markdown 出力
+- **一貫性**: 既存の Claude エージェントと完全に同じ抽象度
+- **包括的テスト**: 各エージェント 7 つのテストケース、全て通過
+- **統合**: main.rs とモジュールシステムに正常統合
+
+### 📊 テスト結果
+
+#### GitHub エージェント
+
+```
+running 7 tests
+test agents::github::tests::test_get_output_path ... ok
+test agents::github::tests::test_generate_empty ... ok
+test agents::github::tests::test_generate_with_content ... ok
+test agents::github::tests::test_generate_creates_pure_markdown ... ok
+test agents::github::tests::test_generate_output_mode_ignored ... ok
+test agents::github::tests::test_generate_with_subdirectory ... ok
+test agents::github::tests::test_generate_multiple_files ... ok
+
+test result: ok. 7 passed; 0 failed
+```
+
+#### Cline エージェント
+
+```
+running 7 tests
+test agents::cline::tests::test_get_output_path ... ok
+test agents::cline::tests::test_generate_empty ... ok
+test agents::cline::tests::test_generate_output_mode_ignored ... ok
+test agents::cline::tests::test_generate_creates_pure_markdown ... ok
+test agents::cline::tests::test_generate_with_content ... ok
+test agents::cline::tests::test_generate_with_subdirectory ... ok
+test agents::cline::tests::test_generate_multiple_files ... ok
+
+test result: ok. 7 passed; 0 failed
+```
+
+### 🔧 動作確認
+
+#### 個別エージェント実行
+
+```bash
+# GitHub エージェント
+cargo run -- generate --agent github
+# ✅ GITHUB.md が正常に生成
+
+# Cline エージェント
+cargo run -- generate --agent cline
+# ✅ CLINE.md が正常に生成
+```
+
+#### 全エージェント同時実行
+
+```bash
+cargo run -- generate
+# ✅ Cursor（split）、Claude、GitHub、Cline（merged）全て正常生成
+```
+
+### 📄 生成ファイル
+
+- **GITHUB.md**: ai-context/ 配下の全 Markdown を結合した純粋な Markdown
+- **CLINE.md**: ai-context/ 配下の全 Markdown を結合した純粋な Markdown
+- **.cursor/rules/\*.mdc**: split モードで個別ファイル（MDC 形式）
+- **CLAUDE.md**: merged モードで結合ファイル（純粋な Markdown）
+
+### 🎉 ミッション完了
+
+GitHub と Cline エージェント用の設定ファイル出力機能が正常に実装され、Claude エージェントと完全に一貫性のあるシンプルな設計で統合されました！
+
+**成果物**:
+
+- 4 つの AI エージェント（Cursor、Claude、GitHub、Cline）がサポート対象となりました
+- 各エージェントのテストが完備され、品質が保証されています
+- シンプル化原則に従い、不要な機能を追加せず完璧な実装となりました

--- a/src/agents/cline.rs
+++ b/src/agents/cline.rs
@@ -1,0 +1,209 @@
+/*!
+ * AI Context Management Tool - Cline Agent (Simplified)
+ *
+ * シンプル化された Cline エージェントの実装
+ * Cline 用の CLINE.md を出力（merged モードのみ対応）
+ */
+
+use crate::core::MarkdownMerger;
+use crate::types::{AIContextConfig, GeneratedFile};
+use anyhow::Result;
+
+/// Cline エージェント（シンプル版）
+pub struct ClineAgent {
+    config: AIContextConfig,
+}
+
+impl ClineAgent {
+    /// 新しい Cline エージェントを作成
+    pub fn new(config: AIContextConfig) -> Self {
+        Self { config }
+    }
+
+    /// Cline 用ファイルを生成（merged モードのみ）
+    pub async fn generate(&self) -> Result<Vec<GeneratedFile>> {
+        let merger = MarkdownMerger::new(self.config.clone());
+        self.generate_merged(&merger).await
+    }
+
+    /// 統合モード：1つのファイルに結合して CLINE.md として出力
+    async fn generate_merged(&self, merger: &MarkdownMerger) -> Result<Vec<GeneratedFile>> {
+        let content = merger.merge_all().await?;
+        let output_path = self.get_output_path();
+
+        Ok(vec![GeneratedFile::new(output_path, content)])
+    }
+
+    /// 出力パスを取得（プロジェクトルートの CLINE.md）
+    fn get_output_path(&self) -> String {
+        "CLINE.md".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{AgentConfig, OutputMode};
+    use tempfile::tempdir;
+    use tokio::fs;
+
+    fn create_test_config(base_dir: &str) -> AIContextConfig {
+        AIContextConfig {
+            version: "1.0".to_string(),
+            output_mode: OutputMode::Merged, // Cline は merged のみ
+            base_docs_dir: base_dir.to_string(),
+            agents: AgentConfig::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_generate_empty() {
+        let temp_dir = tempdir().unwrap();
+        let config = create_test_config(&temp_dir.path().to_string_lossy());
+        let agent = ClineAgent::new(config);
+
+        let files = agent.generate().await.unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "CLINE.md");
+        // 空のディレクトリの場合は空のコンテンツでも正常
+        // （MarkdownMerger が空のディレクトリに対して空文字列を返すため）
+    }
+
+    #[tokio::test]
+    async fn test_generate_with_content() {
+        let temp_dir = tempdir().unwrap();
+        let docs_path = temp_dir.path();
+
+        // テスト用ファイルを作成
+        fs::write(docs_path.join("test.md"), "# Test Content\nThis is a test.")
+            .await
+            .unwrap();
+
+        let config = create_test_config(&docs_path.to_string_lossy());
+        let agent = ClineAgent::new(config);
+
+        let files = agent.generate().await.unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "CLINE.md");
+
+        // ファイル名のヘッダーが含まれることを確認
+        assert!(files[0].content.contains("# test.md"));
+        // 元のコンテンツが含まれることを確認
+        assert!(files[0].content.contains("# Test Content"));
+        assert!(files[0].content.contains("This is a test."));
+
+        // 純粋な Markdown（frontmatter なし）であることを確認
+        assert!(!files[0].content.starts_with("---"));
+    }
+
+    #[tokio::test]
+    async fn test_generate_multiple_files() {
+        let temp_dir = tempdir().unwrap();
+        let docs_path = temp_dir.path();
+
+        // 複数のテスト用ファイルを作成
+        fs::write(docs_path.join("file1.md"), "Content 1")
+            .await
+            .unwrap();
+        fs::write(docs_path.join("file2.md"), "Content 2")
+            .await
+            .unwrap();
+
+        let config = create_test_config(&docs_path.to_string_lossy());
+        let agent = ClineAgent::new(config);
+
+        let files = agent.generate().await.unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "CLINE.md");
+
+        // 両方のファイルの内容が含まれることを確認
+        assert!(files[0].content.contains("Content 1"));
+        assert!(files[0].content.contains("Content 2"));
+
+        // ファイル名のヘッダーが含まれることを確認
+        assert!(files[0].content.contains("# file1.md"));
+        assert!(files[0].content.contains("# file2.md"));
+    }
+
+    #[tokio::test]
+    async fn test_generate_with_subdirectory() {
+        let temp_dir = tempdir().unwrap();
+        let docs_path = temp_dir.path();
+
+        // サブディレクトリを作成
+        let sub_dir = docs_path.join("subdir");
+        fs::create_dir(&sub_dir).await.unwrap();
+        fs::write(sub_dir.join("nested.md"), "Nested content")
+            .await
+            .unwrap();
+
+        let config = create_test_config(&docs_path.to_string_lossy());
+        let agent = ClineAgent::new(config);
+
+        let files = agent.generate().await.unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "CLINE.md");
+
+        // サブディレクトリのファイルも含まれることを確認
+        assert!(files[0].content.contains("Nested content"));
+        assert!(files[0].content.contains("# subdir/nested.md"));
+    }
+
+    #[tokio::test]
+    async fn test_get_output_path() {
+        let config = create_test_config("./docs");
+        let agent = ClineAgent::new(config);
+
+        let output_path = agent.get_output_path();
+        assert_eq!(output_path, "CLINE.md");
+    }
+
+    #[tokio::test]
+    async fn test_generate_creates_pure_markdown() {
+        let temp_dir = tempdir().unwrap();
+        let docs_path = temp_dir.path();
+
+        // テスト用ファイルを作成
+        fs::write(docs_path.join("test.md"), "# Test\nContent here")
+            .await
+            .unwrap();
+
+        let config = create_test_config(&docs_path.to_string_lossy());
+        let agent = ClineAgent::new(config);
+
+        let files = agent.generate().await.unwrap();
+        let content = &files[0].content;
+
+        // 純粋な Markdown であることを確認（YAML frontmatter なし）
+        assert!(!content.starts_with("---"));
+        assert!(!content.contains("description:"));
+        assert!(!content.contains("alwaysApply:"));
+
+        // 内容は含まれていることを確認
+        assert!(content.contains("# Test"));
+        assert!(content.contains("Content here"));
+    }
+
+    #[tokio::test]
+    async fn test_generate_output_mode_ignored() {
+        let temp_dir = tempdir().unwrap();
+        let docs_path = temp_dir.path();
+
+        // テスト用ファイルを作成
+        fs::write(docs_path.join("test.md"), "Test content")
+            .await
+            .unwrap();
+
+        // Split モードで設定しても Cline は merged で動作することを確認
+        let mut config = create_test_config(&docs_path.to_string_lossy());
+        config.output_mode = OutputMode::Split;
+
+        let agent = ClineAgent::new(config);
+        let files = agent.generate().await.unwrap();
+
+        // Split モードを指定しても 1 つのファイルのみ生成される
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "CLINE.md");
+        assert!(files[0].content.contains("Test content"));
+    }
+}

--- a/src/agents/github.rs
+++ b/src/agents/github.rs
@@ -1,0 +1,209 @@
+/*!
+ * AI Context Management Tool - GitHub Agent (Simplified)
+ *
+ * シンプル化された GitHub エージェントの実装
+ * GitHub 用の GITHUB.md を出力（merged モードのみ対応）
+ */
+
+use crate::core::MarkdownMerger;
+use crate::types::{AIContextConfig, GeneratedFile};
+use anyhow::Result;
+
+/// GitHub エージェント（シンプル版）
+pub struct GitHubAgent {
+    config: AIContextConfig,
+}
+
+impl GitHubAgent {
+    /// 新しい GitHub エージェントを作成
+    pub fn new(config: AIContextConfig) -> Self {
+        Self { config }
+    }
+
+    /// GitHub 用ファイルを生成（merged モードのみ）
+    pub async fn generate(&self) -> Result<Vec<GeneratedFile>> {
+        let merger = MarkdownMerger::new(self.config.clone());
+        self.generate_merged(&merger).await
+    }
+
+    /// 統合モード：1つのファイルに結合して GITHUB.md として出力
+    async fn generate_merged(&self, merger: &MarkdownMerger) -> Result<Vec<GeneratedFile>> {
+        let content = merger.merge_all().await?;
+        let output_path = self.get_output_path();
+
+        Ok(vec![GeneratedFile::new(output_path, content)])
+    }
+
+    /// 出力パスを取得（プロジェクトルートの GITHUB.md）
+    fn get_output_path(&self) -> String {
+        "GITHUB.md".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{AgentConfig, OutputMode};
+    use tempfile::tempdir;
+    use tokio::fs;
+
+    fn create_test_config(base_dir: &str) -> AIContextConfig {
+        AIContextConfig {
+            version: "1.0".to_string(),
+            output_mode: OutputMode::Merged, // GitHub は merged のみ
+            base_docs_dir: base_dir.to_string(),
+            agents: AgentConfig::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_generate_empty() {
+        let temp_dir = tempdir().unwrap();
+        let config = create_test_config(&temp_dir.path().to_string_lossy());
+        let agent = GitHubAgent::new(config);
+
+        let files = agent.generate().await.unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "GITHUB.md");
+        // 空のディレクトリの場合は空のコンテンツでも正常
+        // （MarkdownMerger が空のディレクトリに対して空文字列を返すため）
+    }
+
+    #[tokio::test]
+    async fn test_generate_with_content() {
+        let temp_dir = tempdir().unwrap();
+        let docs_path = temp_dir.path();
+
+        // テスト用ファイルを作成
+        fs::write(docs_path.join("test.md"), "# Test Content\nThis is a test.")
+            .await
+            .unwrap();
+
+        let config = create_test_config(&docs_path.to_string_lossy());
+        let agent = GitHubAgent::new(config);
+
+        let files = agent.generate().await.unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "GITHUB.md");
+
+        // ファイル名のヘッダーが含まれることを確認
+        assert!(files[0].content.contains("# test.md"));
+        // 元のコンテンツが含まれることを確認
+        assert!(files[0].content.contains("# Test Content"));
+        assert!(files[0].content.contains("This is a test."));
+
+        // 純粋な Markdown（frontmatter なし）であることを確認
+        assert!(!files[0].content.starts_with("---"));
+    }
+
+    #[tokio::test]
+    async fn test_generate_multiple_files() {
+        let temp_dir = tempdir().unwrap();
+        let docs_path = temp_dir.path();
+
+        // 複数のテスト用ファイルを作成
+        fs::write(docs_path.join("file1.md"), "Content 1")
+            .await
+            .unwrap();
+        fs::write(docs_path.join("file2.md"), "Content 2")
+            .await
+            .unwrap();
+
+        let config = create_test_config(&docs_path.to_string_lossy());
+        let agent = GitHubAgent::new(config);
+
+        let files = agent.generate().await.unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "GITHUB.md");
+
+        // 両方のファイルの内容が含まれることを確認
+        assert!(files[0].content.contains("Content 1"));
+        assert!(files[0].content.contains("Content 2"));
+
+        // ファイル名のヘッダーが含まれることを確認
+        assert!(files[0].content.contains("# file1.md"));
+        assert!(files[0].content.contains("# file2.md"));
+    }
+
+    #[tokio::test]
+    async fn test_generate_with_subdirectory() {
+        let temp_dir = tempdir().unwrap();
+        let docs_path = temp_dir.path();
+
+        // サブディレクトリを作成
+        let sub_dir = docs_path.join("subdir");
+        fs::create_dir(&sub_dir).await.unwrap();
+        fs::write(sub_dir.join("nested.md"), "Nested content")
+            .await
+            .unwrap();
+
+        let config = create_test_config(&docs_path.to_string_lossy());
+        let agent = GitHubAgent::new(config);
+
+        let files = agent.generate().await.unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "GITHUB.md");
+
+        // サブディレクトリのファイルも含まれることを確認
+        assert!(files[0].content.contains("Nested content"));
+        assert!(files[0].content.contains("# subdir/nested.md"));
+    }
+
+    #[tokio::test]
+    async fn test_get_output_path() {
+        let config = create_test_config("./docs");
+        let agent = GitHubAgent::new(config);
+
+        let output_path = agent.get_output_path();
+        assert_eq!(output_path, "GITHUB.md");
+    }
+
+    #[tokio::test]
+    async fn test_generate_creates_pure_markdown() {
+        let temp_dir = tempdir().unwrap();
+        let docs_path = temp_dir.path();
+
+        // テスト用ファイルを作成
+        fs::write(docs_path.join("test.md"), "# Test\nContent here")
+            .await
+            .unwrap();
+
+        let config = create_test_config(&docs_path.to_string_lossy());
+        let agent = GitHubAgent::new(config);
+
+        let files = agent.generate().await.unwrap();
+        let content = &files[0].content;
+
+        // 純粋な Markdown であることを確認（YAML frontmatter なし）
+        assert!(!content.starts_with("---"));
+        assert!(!content.contains("description:"));
+        assert!(!content.contains("alwaysApply:"));
+
+        // 内容は含まれていることを確認
+        assert!(content.contains("# Test"));
+        assert!(content.contains("Content here"));
+    }
+
+    #[tokio::test]
+    async fn test_generate_output_mode_ignored() {
+        let temp_dir = tempdir().unwrap();
+        let docs_path = temp_dir.path();
+
+        // テスト用ファイルを作成
+        fs::write(docs_path.join("test.md"), "Test content")
+            .await
+            .unwrap();
+
+        // Split モードで設定しても GitHub は merged で動作することを確認
+        let mut config = create_test_config(&docs_path.to_string_lossy());
+        config.output_mode = OutputMode::Split;
+
+        let agent = GitHubAgent::new(config);
+        let files = agent.generate().await.unwrap();
+
+        // Split モードを指定しても 1 つのファイルのみ生成される
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "GITHUB.md");
+        assert!(files[0].content.contains("Test content"));
+    }
+}

--- a/src/agents/mod.rs
+++ b/src/agents/mod.rs
@@ -6,7 +6,11 @@
 
 pub mod base;
 pub mod claude;
+pub mod cline;
 pub mod cursor;
+pub mod github;
 
 pub use claude::*;
+pub use cline::*;
 pub use cursor::*;
+pub use github::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,9 @@
  */
 
 use aicm::agents::claude::ClaudeAgent;
+use aicm::agents::cline::ClineAgent;
 use aicm::agents::cursor::CursorAgent;
+use aicm::agents::github::GitHubAgent;
 use aicm::config::{error::ConfigError, loader::ConfigLoader};
 use aicm::types::{AIContextConfig, GeneratedFile};
 use anyhow::Result;
@@ -249,6 +251,14 @@ async fn generate_agent_files(
         }
         "claude" => {
             let agent = ClaudeAgent::new(config.clone());
+            agent.generate().await
+        }
+        "github" => {
+            let agent = GitHubAgent::new(config.clone());
+            agent.generate().await
+        }
+        "cline" => {
+            let agent = ClineAgent::new(config.clone());
             agent.generate().await
         }
         _ => Err(anyhow::anyhow!("未対応のエージェント: {}", agent_name)),


### PR DESCRIPTION
GitHub と Cline エージェント用の設定ファイル出力機能を実装。GITHUB.md と CLINE.md をプロジェクトルートに出力。Claude エージェントと同じパターンでシンプルに実装。全テスト通過。