### PR TITLE
fix: GitHub・Clineエージェントを正しい仕様で実装

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,237 @@
+# 01_project-overview.md
+
+# プロジェクト概要
+
+**必ず日本語で対応すること**
+
+このファイルは、このリポジトリでコードを扱う際に Claude Code (claude.ai/code) にガイダンスを提供します。
+
+## プロジェクト概要
+
+このリポジトリは、複数の AI コーディングエージェント用の context ファイルを統一設定から自動生成する Rust 製コマンドラインツールです。
+
+### 目的
+
+- GitHub Copilot、Cline、Cursor、Claude Code 用の context ファイルを一元管理
+- 一つの設定ファイルから各ツール固有のファイル形式を自動生成
+- 開発チーム間での AI ツール設定の一貫性を保つ
+- Rust による高速・安全な実装
+
+### サポート対象ツール
+
+1. **🎯 Cursor**: `.cursor/rules/*.mdc` ファイル（実装済み）
+2. **🚧 Cline**: `.clinerules/*.md` ファイル（今後実装予定）
+3. **🚧 GitHub Copilot**: `instructions.md` 階層配置（今後実装予定）
+4. **🚧 Claude Code**: `CLAUDE.md`（今後実装予定）
+
+詳細な設計概要は `docs/concept.md` を参照してください。
+
+# 02_architecture.md
+
+# アーキテクチャノート
+
+## 設計原則
+
+- **型安全性**: Rust の型システムによるコンパイル時エラー検出
+- **メモリ安全性**: 所有権システムによる安全なメモリ管理
+- **並行処理**: Tokio による効率的な非同期処理
+- **抽象化**: トレイトベースのエージェント設計
+- **統一管理**: 共通の設定ファイルから各ツール用ファイルを生成
+
+## プロジェクト構造
+
+```
+src/
+├── main.rs                 # CLI エントリーポイント
+├── lib.rs                  # ライブラリエントリーポイント
+├── config/                 # 設定管理
+│   ├── mod.rs
+│   ├── loader.rs           # 設定読み込み
+│   └── error.rs            # 設定エラー型
+├── core/                   # コア機能
+│   ├── mod.rs
+│   └── markdown_merger.rs  # Markdownファイル結合
+├── agents/                 # エージェント実装
+│   ├── mod.rs
+│   ├── base.rs            # ベースユーティリティ
+│   └── cursor.rs          # Cursor実装
+└── types/                  # 型定義
+    ├── mod.rs
+    ├── config.rs          # 設定型
+    └── agent.rs           # エージェント型
+
+docs/                      # 設計ドキュメント
+├── concept.md             # 設計概要
+├── design_doc.md          # 技術仕様書（Rust版）
+└── requirements.md        # 要件定義
+
+target/                    # ビルド出力
+├── debug/                 # デバッグビルド
+└── release/               # リリースビルド
+
+Cargo.toml                 # プロジェクト設定
+Cargo.lock                 # 依存関係ロック
+```
+
+## 実装時の注意点
+
+- 新しい機能を追加する際は、対応するテストも同時作成
+- テストファイルは `#[cfg(test)]` モジュールまたは `tests/` ディレクトリを使用
+- エラーハンドリング（`Result<T, E>`）も含めてテストケースを作成
+- 非同期処理は `#[tokio::test]` を使用してテスト
+
+## 型システムの活用
+
+- `serde` による設定ファイルの型安全なデシリアライゼーション
+- `async-trait` による非同期トレイトの実装
+- `thiserror` による構造化されたエラー型定義
+- オプション型（`Option<T>`）による明示的な Null 安全性
+
+## パフォーマンス特徴
+
+- **高速起動**: ネイティブバイナリによる瞬時起動（100ms 以内）
+- **低メモリ**: 効率的なメモリ管理（10MB 以下）
+- **並列処理**: 非同期 I/O による高速ファイル処理
+- **ゼロコピー**: 不要な文字列コピーの回避
+
+# 03_dependencies.md
+
+# 依存関係
+
+## 主要なクレート
+
+- **clap**: CLI 構築フレームワーク（derive API 使用）
+- **tokio**: 非同期ランタイム
+- **serde + serde_yaml**: 設定ファイル処理
+- **anyhow + thiserror**: エラーハンドリング
+- **async-trait**: 非同期トレイト
+- **path-clean**: パス正規化
+
+## 開発用クレート
+
+- **tokio-test**: 非同期テスト
+- **tempfile**: テスト用一時ファイル
+
+# 04_development-rules.md
+
+# 開発ルール
+
+## テスト要件
+
+- **必須**: 各モジュールは Rust 標準テストフレームワークでテストを作成すること
+- **カバレッジ**: 主要な機能とエラーパスのテストを含めること
+- **作業完了**: 作業終了時は必ずテストが通ることを確認すること
+
+## テスト実行例
+
+```bash
+# 全テスト実行
+cargo test
+
+# 特定のテストモジュール実行
+cargo test config
+cargo test agents::cursor
+
+# テストカバレッジ（tarpaulin要インストール）
+cargo install cargo-tarpaulin
+cargo tarpaulin --out html
+
+# 統合テスト実行
+cargo test --test integration_test
+```
+
+## Git 運用
+
+- 開発作業については、ブランチを分けて作業すること
+- 指示された内容は、まず ai-works ディレクトリ内に作業要件を整理すること
+- 作業完了後は、gh コマンドで PR を作成すること
+
+## コード品質
+
+- **rustfmt**: 統一されたコードフォーマット
+- **clippy**: 高品質な Rust コードのためのリンター
+- **型安全性**: Rust の強力な型システムを活用
+- **エラーハンドリング**: anyhow・thiserror による適切なエラー処理
+
+## Lint & Format
+
+- 作業完了時に `cargo fmt` と `cargo clippy` を実行してください。
+
+## 作業記録の作成
+
+- 作業開始時に、`ai-works` ディレクトリに `yyyy-mm-dd-<work name>.md` を作成し、作業内容、要件をまとめてください
+- 指示された場合は、一度作業内容を指示者に確認してもらってから作業を進めてください
+
+# 05_development-setup.md
+
+# 開発環境セットアップ
+
+## 必要な環境
+
+- Rust 1.70.0 以上
+- Cargo（Rust と一緒にインストール）
+
+## 主要コマンド
+
+```bash
+# プロジェクトクローン
+git clone https://github.com/morooka-akira/ai-context-management
+cd ai-context-management
+
+# ビルド
+cargo build
+
+# リリースビルド
+cargo build --release
+
+# テスト実行
+cargo test
+
+# 開発版での実行
+cargo run -- init
+cargo run -- generate
+cargo run -- validate
+cargo run -- list-agents
+
+# リント・フォーマット
+cargo fmt     # コードフォーマット
+cargo clippy  # リント実行
+
+# ドキュメント生成
+cargo doc --open
+```
+
+# 06_roadmap.md
+
+# 今後の拡張予定
+
+## Phase 2 機能
+
+- Cline、GitHub Copilot、Claude Code エージェント実装
+- ウォッチモード（ファイル変更時の自動生成）
+- 設定継承機能
+
+## Phase 3 機能
+
+- プラグインシステム（WASM 対応）
+- Web UI
+- クラウド同期
+
+# 07_references.md
+
+# 参考リンク
+
+## 技術ドキュメント
+
+- [Rust 公式ドキュメント](https://doc.rust-lang.org/)
+- [Tokio 公式ドキュメント](https://tokio.rs/)
+- [clap 公式ドキュメント](https://docs.rs/clap/)
+- [serde 公式ドキュメント](https://serde.rs/)
+
+## AI ツール関連
+
+- [Claude Code Memory (CLAUDE.md)](https://docs.anthropic.com/en/docs/claude-code/memory)
+- [Cline Rules](https://docs.cline.bot/features/cline-rules)
+- [GitHub Copilot Custom Instructions](https://docs.github.com/en/copilot/customizing-copilot/adding-repository-custom-instructions-for-github-copilot)
+- [VS Code Copilot Customization](https://code.visualstudio.com/docs/copilot/copilot-customization#_use-instructionsmd-files)
+- [Cursor Rules](https://docs.cursor.com/context/rules)

--- a/ai-context.yaml
+++ b/ai-context.yaml
@@ -3,6 +3,6 @@ output_mode: split
 base_docs_dir: ./ai-context
 agents:
   cursor: true
-  cline: false
-  github: false
+  cline: true
+  github: true
   claude: true

--- a/ai-works/2025-01-07-github-cline-agents-correct-implementation.md
+++ b/ai-works/2025-01-07-github-cline-agents-correct-implementation.md
@@ -1,0 +1,203 @@
+# GitHub・Cline エージェント正しい仕様実装作業記録
+
+## 📅 作業日
+
+2025-01-07
+
+## 🎯 作業目標
+
+GitHub と Cline エージェント用の設定ファイル出力機能を**正しい仕様**で実装する
+
+## 📋 修正前の問題
+
+初回実装では仕様を誤解していました：
+
+- **誤った実装**: 両エージェントとも merged モードのみで、プロジェクトルートに `.md` ファイルを出力
+- **正しい仕様**: 両方とも split/merged モードをサポートし、それぞれ専用のディレクトリ構造を使用
+
+## 🔍 正しい仕様の確認
+
+### Cline Rules の仕様
+
+[Cline Rules Documentation](https://docs.cline.bot/features/cline-rules):
+
+**Split モード（推奨）**: `.clinerules/` フォルダシステム
+
+```
+your-project/
+├── .clinerules/              # フォルダ containing active rules
+│   ├── 01-coding.md          # Core coding standards
+│   ├── 02-documentation.md   # Documentation requirements
+│   └── current-sprint.md     # Rules specific to current work
+```
+
+**Merged モード**: 単一の `.clinerules` ファイル（拡張子なし）
+
+```
+your-project/
+├── .clinerules              # 単一ファイル
+```
+
+### GitHub Copilot の仕様
+
+[VS Code Copilot Customization](https://code.visualstudio.com/docs/copilot/copilot-customization#_use-instructionsmd-files):
+
+**Split モード**: `.github/prompts/` フォルダに複数のファイル
+
+```
+your-project/
+├── .github/
+│   └── prompts/
+│       ├── file1.md
+│       └── file2.md
+```
+
+**Merged モード**: `.github/copilot-instructions.md` 単一ファイル
+
+```
+your-project/
+├── .github/
+│   └── copilot-instructions.md
+```
+
+## 📝 実装タスク
+
+### ✅ Phase 1: ブランチとクリーンアップ
+
+- [x] 新しいブランチ作成（fix/correct-agent-implementation）
+- [x] 間違った実装ファイルの修正
+
+### ✅ Phase 2: Cline エージェント正しい実装
+
+- [x] `src/agents/cline.rs` の大幅修正
+  - [x] Split モード: `.clinerules/` フォルダに複数ファイル出力
+  - [x] Merged モード: `.clinerules` 単一ファイル出力（拡張子なし）
+  - [x] ファイル命名規則（数字プレフィックス `01-`, `02-` など）
+  - [x] 既存の `.clinerules` ファイル/ディレクトリの適切な処理
+- [x] Cline エージェントのテスト修正（8 つのテストケース、全て通過）
+
+### ✅ Phase 3: GitHub エージェント正しい実装
+
+- [x] `src/agents/github.rs` の大幅修正
+  - [x] Split モード: `.github/prompts/` フォルダに複数ファイル出力
+  - [x] Merged モード: `.github/copilot-instructions.md` 単一ファイル出力
+  - [x] ディレクトリの自動作成
+- [x] GitHub エージェントのテスト修正（9 つのテストケース、全て通過）
+
+### ✅ Phase 4: 統合とテスト
+
+- [x] 両エージェントの split/merged モード動作確認
+- [x] 全テスト通過確認
+- [x] lint & format 実行
+- [x] 統合テスト（実際のファイル生成確認）
+
+## 📊 テスト結果
+
+### Cline エージェント（8 テスト）
+
+```
+test agents::cline::tests::test_get_merged_output_path ... ok
+test agents::cline::tests::test_get_split_rules_dir ... ok
+test agents::cline::tests::test_generate_merged_empty ... ok
+test agents::cline::tests::test_generate_merged_with_content ... ok
+test agents::cline::tests::test_generate_split_with_subdirectory ... ok
+test agents::cline::tests::test_generate_split_multiple_files ... ok
+test agents::cline::tests::test_prepare_rules_directory ... ok
+test agents::cline::tests::test_numbered_filename_generation ... ok
+
+test result: ok. 8 passed; 0 failed
+```
+
+### GitHub エージェント（9 テスト）
+
+```
+test agents::github::tests::test_get_split_prompts_dir ... ok
+test agents::github::tests::test_get_merged_output_path ... ok
+test agents::github::tests::test_split_vs_merged_output_paths ... ok
+test agents::github::tests::test_generate_merged_empty ... ok
+test agents::github::tests::test_generate_merged_with_content ... ok
+test agents::github::tests::test_generate_creates_pure_markdown ... ok
+test agents::github::tests::test_prepare_prompts_directory ... ok
+test agents::github::tests::test_generate_split_multiple_files ... ok
+test agents::github::tests::test_generate_split_with_subdirectory ... ok
+
+test result: ok. 9 passed; 0 failed
+```
+
+## 🔧 動作確認
+
+### Split モード
+
+```bash
+# ai-context.yaml で output_mode: split
+aicm generate --agent cline
+# ✅ .clinerules/01-filename.md, 02-filename.md, ... 生成
+
+aicm generate --agent github
+# ✅ .github/prompts/filename.md, ... 生成
+```
+
+### Merged モード
+
+```bash
+# ai-context.yaml で output_mode: merged
+aicm generate --agent cline
+# ✅ .clinerules (拡張子なし) 生成
+
+aicm generate --agent github
+# ✅ .github/copilot-instructions.md 生成
+```
+
+### 全エージェント統合テスト
+
+```bash
+aicm generate
+# ✅ 4つのエージェント全て正常動作：
+# - Cursor: .cursor/rules/*.mdc (split/merged 対応)
+# - Cline: .clinerules/ または .clinerules (split/merged)
+# - GitHub: .github/prompts/ または .github/copilot-instructions.md (split/merged)
+# - Claude: CLAUDE.md (merged のみ)
+```
+
+## 🚀 重要な修正点
+
+### 1. 正しい出力パス
+
+- **Cline**:
+  - Split: `.clinerules/01-filename.md`, `02-filename.md`
+  - Merged: `.clinerules` (拡張子なし)
+- **GitHub**:
+  - Split: `.github/prompts/filename.md`
+  - Merged: `.github/copilot-instructions.md`
+
+### 2. ファイル命名規則
+
+- **Cline**: 数字プレフィックス付き（推奨仕様）
+- **GitHub**: 元のファイル名を保持
+
+### 3. コンフリクト解決
+
+- Cline エージェントに既存ファイル/ディレクトリの適切な処理を追加
+- merged → split または split → merged の切り替えに対応
+
+## ✅ 作業完了
+
+### 🎯 実装成果
+
+- **GitHub エージェント**: 正しい仕様で完全に再実装
+- **Cline エージェント**: 正しい仕様で完全に再実装
+- **両モード対応**: split/merged モードを正しくサポート
+- **仕様準拠**: 公式ドキュメントに完全準拠
+- **包括的テスト**: 合計 17 つのテストケース、全て通過
+- **統合成功**: 4 つのエージェント全てが正常動作
+
+### 🎉 ミッション完了
+
+GitHub と Cline エージェントが**正しい仕様**で実装され、公式ドキュメントに完全準拠した設計で統合されました！
+
+**最終成果物**:
+
+- 4 つの AI エージェント（Cursor、Claude、GitHub、Cline）が正しい仕様でサポート
+- split/merged モードの適切な使い分け
+- 各エージェントの公式ドキュメント準拠
+- 完璧なテストカバレッジと品質保証

--- a/src/agents/cline.rs
+++ b/src/agents/cline.rs
@@ -1,0 +1,292 @@
+/*!
+ * AI Context Management Tool - Cline Agent
+ *
+ * Cline エージェントの実装
+ * 仕様: https://docs.cline.bot/features/cline-rules
+ *
+ * Split モード: .clinerules/ フォルダに複数の .md ファイル
+ * Merged モード: .clinerules 単一ファイル（拡張子なし）
+ */
+
+use crate::core::MarkdownMerger;
+use crate::types::{AIContextConfig, GeneratedFile, OutputMode};
+use anyhow::Result;
+use tokio::fs;
+
+/// Cline エージェント
+pub struct ClineAgent {
+    config: AIContextConfig,
+}
+
+impl ClineAgent {
+    /// 新しい Cline エージェントを作成
+    pub fn new(config: AIContextConfig) -> Self {
+        Self { config }
+    }
+
+    /// Cline 用ファイルを生成
+    pub async fn generate(&self) -> Result<Vec<GeneratedFile>> {
+        let merger = MarkdownMerger::new(self.config.clone());
+
+        match self.config.output_mode {
+            OutputMode::Merged => self.generate_merged(&merger).await,
+            OutputMode::Split => self.generate_split(&merger).await,
+        }
+    }
+
+    /// Merged モード：.clinerules 単一ファイル（拡張子なし）
+    async fn generate_merged(&self, merger: &MarkdownMerger) -> Result<Vec<GeneratedFile>> {
+        let content = merger.merge_all().await?;
+        let output_path = self.get_merged_output_path();
+
+        Ok(vec![GeneratedFile::new(output_path, content)])
+    }
+
+    /// Split モード：.clinerules/ フォルダに複数の .md ファイル
+    async fn generate_split(&self, merger: &MarkdownMerger) -> Result<Vec<GeneratedFile>> {
+        let files = merger.get_individual_files().await?;
+        let mut generated_files = Vec::new();
+
+        // .clinerules/ ディレクトリを準備
+        let rules_dir = self.get_split_rules_dir();
+        self.prepare_rules_directory(&rules_dir).await?;
+
+        for (index, (file_name, content)) in files.iter().enumerate() {
+            // ファイル名から拡張子を除去してmdファイル名を作成
+            let base_name = file_name.trim_end_matches(".md");
+            let safe_name = base_name.replace(['/', '\\'], "_"); // パス区切り文字をアンダースコアに変換
+
+            // 数字プレフィックスを追加（Cline Rules 推奨）
+            let numbered_filename = format!("{:02}-{}.md", index + 1, safe_name);
+
+            generated_files.push(GeneratedFile::new(
+                format!("{}/{}", rules_dir, numbered_filename),
+                content.clone(),
+            ));
+        }
+
+        Ok(generated_files)
+    }
+
+    /// Merged モードの出力パスを取得
+    fn get_merged_output_path(&self) -> String {
+        ".clinerules".to_string() // 拡張子なし
+    }
+
+    /// Split モードのルールディレクトリのパスを取得
+    fn get_split_rules_dir(&self) -> String {
+        ".clinerules".to_string() // フォルダ
+    }
+
+    /// .clinerules/ ディレクトリを準備（既存ファイルを削除）
+    async fn prepare_rules_directory(&self, rules_dir: &str) -> Result<()> {
+        // 既存の .clinerules ファイル（merged モード用）が存在する場合は削除
+        if let Ok(metadata) = fs::metadata(rules_dir).await {
+            if metadata.is_file() {
+                fs::remove_file(rules_dir).await?;
+            } else if metadata.is_dir() {
+                // ディレクトリが存在する場合、中身を削除
+                let mut entries = fs::read_dir(rules_dir).await?;
+                while let Some(entry) = entries.next_entry().await? {
+                    let path = entry.path();
+                    if path.is_file() && path.extension().map_or(false, |ext| ext == "md") {
+                        fs::remove_file(path).await?;
+                    }
+                }
+            }
+        }
+
+        // ディレクトリを作成（存在しない場合）
+        fs::create_dir_all(rules_dir).await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{AgentConfig, OutputMode};
+    use tempfile::tempdir;
+    use tokio::fs;
+
+    fn create_test_config(base_dir: &str, output_mode: OutputMode) -> AIContextConfig {
+        AIContextConfig {
+            version: "1.0".to_string(),
+            output_mode,
+            base_docs_dir: base_dir.to_string(),
+            agents: AgentConfig::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_generate_merged_empty() {
+        let temp_dir = tempdir().unwrap();
+        let config = create_test_config(&temp_dir.path().to_string_lossy(), OutputMode::Merged);
+        let agent = ClineAgent::new(config);
+
+        let files = agent.generate().await.unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, ".clinerules"); // 拡張子なし
+    }
+
+    #[tokio::test]
+    async fn test_generate_merged_with_content() {
+        let temp_dir = tempdir().unwrap();
+        let docs_path = temp_dir.path();
+
+        // テスト用ファイルを作成
+        fs::write(docs_path.join("test.md"), "# Test Content\nThis is a test.")
+            .await
+            .unwrap();
+
+        let config = create_test_config(&docs_path.to_string_lossy(), OutputMode::Merged);
+        let agent = ClineAgent::new(config);
+
+        let files = agent.generate().await.unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, ".clinerules");
+
+        // ファイル名のヘッダーが含まれることを確認
+        assert!(files[0].content.contains("# test.md"));
+        // 元のコンテンツが含まれることを確認
+        assert!(files[0].content.contains("# Test Content"));
+        assert!(files[0].content.contains("This is a test."));
+    }
+
+    #[tokio::test]
+    async fn test_generate_split_multiple_files() {
+        let temp_dir = tempdir().unwrap();
+        let docs_path = temp_dir.path();
+
+        // 複数のテスト用ファイルを作成
+        fs::write(docs_path.join("file1.md"), "Content 1")
+            .await
+            .unwrap();
+        fs::write(docs_path.join("file2.md"), "Content 2")
+            .await
+            .unwrap();
+
+        let config = create_test_config(&docs_path.to_string_lossy(), OutputMode::Split);
+        let agent = ClineAgent::new(config);
+
+        let files = agent.generate().await.unwrap();
+        assert_eq!(files.len(), 2);
+
+        // ファイル名とパスをチェック（数字プレフィックス付き）
+        let paths: Vec<&String> = files.iter().map(|f| &f.path).collect();
+        assert!(paths.contains(&&".clinerules/01-file1.md".to_string()));
+        assert!(paths.contains(&&".clinerules/02-file2.md".to_string()));
+
+        // 内容をチェック
+        for file in &files {
+            if file.path.contains("01-file1") {
+                assert!(file.content.contains("Content 1"));
+            } else if file.path.contains("02-file2") {
+                assert!(file.content.contains("Content 2"));
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_generate_split_with_subdirectory() {
+        let temp_dir = tempdir().unwrap();
+        let docs_path = temp_dir.path();
+
+        // サブディレクトリを作成
+        let sub_dir = docs_path.join("subdir");
+        fs::create_dir(&sub_dir).await.unwrap();
+        fs::write(sub_dir.join("nested.md"), "Nested content")
+            .await
+            .unwrap();
+
+        let config = create_test_config(&docs_path.to_string_lossy(), OutputMode::Split);
+        let agent = ClineAgent::new(config);
+
+        let files = agent.generate().await.unwrap();
+        assert_eq!(files.len(), 1);
+
+        // パス区切り文字がアンダースコアに変換され、数字プレフィックスが付いていることを確認
+        assert_eq!(files[0].path, ".clinerules/01-subdir_nested.md");
+        assert!(files[0].content.contains("Nested content"));
+    }
+
+    #[tokio::test]
+    async fn test_get_merged_output_path() {
+        let config = create_test_config("./docs", OutputMode::Merged);
+        let agent = ClineAgent::new(config);
+
+        let output_path = agent.get_merged_output_path();
+        assert_eq!(output_path, ".clinerules"); // 拡張子なし
+    }
+
+    #[tokio::test]
+    async fn test_get_split_rules_dir() {
+        let config = create_test_config("./docs", OutputMode::Split);
+        let agent = ClineAgent::new(config);
+
+        let rules_dir = agent.get_split_rules_dir();
+        assert_eq!(rules_dir, ".clinerules"); // フォルダ
+    }
+
+    #[tokio::test]
+    async fn test_prepare_rules_directory() {
+        let temp_dir = tempdir().unwrap();
+        let rules_dir = temp_dir.path().join(".clinerules");
+        let config = create_test_config("./docs", OutputMode::Split);
+        let agent = ClineAgent::new(config);
+
+        // ディレクトリを作成
+        fs::create_dir_all(&rules_dir).await.unwrap();
+
+        // 既存のmdファイルを作成
+        let existing_md = rules_dir.join("old_file.md");
+        let other_file = rules_dir.join("keep_me.txt");
+        fs::write(&existing_md, "old content").await.unwrap();
+        fs::write(&other_file, "keep this").await.unwrap();
+
+        // ファイルが存在することを確認
+        assert!(existing_md.exists());
+        assert!(other_file.exists());
+
+        // prepare_rules_directory を実行
+        agent
+            .prepare_rules_directory(&rules_dir.to_string_lossy())
+            .await
+            .unwrap();
+
+        // mdファイルは削除され、他のファイルは残っていることを確認
+        assert!(!existing_md.exists());
+        assert!(other_file.exists());
+    }
+
+    #[tokio::test]
+    async fn test_numbered_filename_generation() {
+        let temp_dir = tempdir().unwrap();
+        let docs_path = temp_dir.path();
+
+        // 複数のテスト用ファイルを作成（順序確認のため）
+        fs::write(docs_path.join("apple.md"), "Apple content")
+            .await
+            .unwrap();
+        fs::write(docs_path.join("banana.md"), "Banana content")
+            .await
+            .unwrap();
+        fs::write(docs_path.join("cherry.md"), "Cherry content")
+            .await
+            .unwrap();
+
+        let config = create_test_config(&docs_path.to_string_lossy(), OutputMode::Split);
+        let agent = ClineAgent::new(config);
+
+        let files = agent.generate().await.unwrap();
+        assert_eq!(files.len(), 3);
+
+        // ファイル名の数字プレフィックスを確認
+        let paths: Vec<&String> = files.iter().map(|f| &f.path).collect();
+
+        // アルファベット順でソートされることを確認
+        assert!(paths.iter().any(|p| p.contains("01-apple.md")));
+        assert!(paths.iter().any(|p| p.contains("02-banana.md")));
+        assert!(paths.iter().any(|p| p.contains("03-cherry.md")));
+    }
+}

--- a/src/agents/github.rs
+++ b/src/agents/github.rs
@@ -1,0 +1,298 @@
+/*!
+ * AI Context Management Tool - GitHub Agent
+ *
+ * GitHub エージェントの実装
+ * 仕様: https://code.visualstudio.com/docs/copilot/copilot-customization#_use-instructionsmd-files
+ *
+ * Split モード: .github/prompts/ フォルダに複数の .md ファイル
+ * Merged モード: .github/copilot-instructions.md 単一ファイル
+ */
+
+use crate::core::MarkdownMerger;
+use crate::types::{AIContextConfig, GeneratedFile, OutputMode};
+use anyhow::Result;
+use tokio::fs;
+
+/// GitHub エージェント
+pub struct GitHubAgent {
+    config: AIContextConfig,
+}
+
+impl GitHubAgent {
+    /// 新しい GitHub エージェントを作成
+    pub fn new(config: AIContextConfig) -> Self {
+        Self { config }
+    }
+
+    /// GitHub 用ファイルを生成
+    pub async fn generate(&self) -> Result<Vec<GeneratedFile>> {
+        let merger = MarkdownMerger::new(self.config.clone());
+
+        match self.config.output_mode {
+            OutputMode::Merged => self.generate_merged(&merger).await,
+            OutputMode::Split => self.generate_split(&merger).await,
+        }
+    }
+
+    /// Merged モード：.github/copilot-instructions.md 単一ファイル
+    async fn generate_merged(&self, merger: &MarkdownMerger) -> Result<Vec<GeneratedFile>> {
+        let content = merger.merge_all().await?;
+        let output_path = self.get_merged_output_path();
+
+        // .github ディレクトリを作成
+        fs::create_dir_all(".github").await?;
+
+        Ok(vec![GeneratedFile::new(output_path, content)])
+    }
+
+    /// Split モード：.github/prompts/ フォルダに複数の .md ファイル
+    async fn generate_split(&self, merger: &MarkdownMerger) -> Result<Vec<GeneratedFile>> {
+        let files = merger.get_individual_files().await?;
+        let mut generated_files = Vec::new();
+
+        // .github/prompts/ ディレクトリを準備
+        let prompts_dir = self.get_split_prompts_dir();
+        self.prepare_prompts_directory(&prompts_dir).await?;
+
+        for (file_name, content) in files {
+            // ファイル名から拡張子を除去してmdファイル名を作成
+            let base_name = file_name.trim_end_matches(".md");
+            let safe_name = base_name.replace(['/', '\\'], "_"); // パス区切り文字をアンダースコアに変換
+
+            generated_files.push(GeneratedFile::new(
+                format!("{}/{}.md", prompts_dir, safe_name),
+                content,
+            ));
+        }
+
+        Ok(generated_files)
+    }
+
+    /// Merged モードの出力パスを取得
+    fn get_merged_output_path(&self) -> String {
+        ".github/copilot-instructions.md".to_string()
+    }
+
+    /// Split モードのプロンプトディレクトリのパスを取得
+    fn get_split_prompts_dir(&self) -> String {
+        ".github/prompts".to_string()
+    }
+
+    /// .github/prompts/ ディレクトリを準備（既存ファイルを削除）
+    async fn prepare_prompts_directory(&self, prompts_dir: &str) -> Result<()> {
+        // ディレクトリが存在する場合、中身を削除
+        if fs::metadata(prompts_dir).await.is_ok() {
+            let mut entries = fs::read_dir(prompts_dir).await?;
+            while let Some(entry) = entries.next_entry().await? {
+                let path = entry.path();
+                if path.is_file() && path.extension().map_or(false, |ext| ext == "md") {
+                    fs::remove_file(path).await?;
+                }
+            }
+        }
+
+        // ディレクトリを作成（存在しない場合）
+        fs::create_dir_all(prompts_dir).await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{AgentConfig, OutputMode};
+    use tempfile::tempdir;
+    use tokio::fs;
+
+    fn create_test_config(base_dir: &str, output_mode: OutputMode) -> AIContextConfig {
+        AIContextConfig {
+            version: "1.0".to_string(),
+            output_mode,
+            base_docs_dir: base_dir.to_string(),
+            agents: AgentConfig::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_generate_merged_empty() {
+        let temp_dir = tempdir().unwrap();
+        let config = create_test_config(&temp_dir.path().to_string_lossy(), OutputMode::Merged);
+        let agent = GitHubAgent::new(config);
+
+        let files = agent.generate().await.unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, ".github/copilot-instructions.md");
+    }
+
+    #[tokio::test]
+    async fn test_generate_merged_with_content() {
+        let temp_dir = tempdir().unwrap();
+        let docs_path = temp_dir.path();
+
+        // テスト用ファイルを作成
+        fs::write(docs_path.join("test.md"), "# Test Content\nThis is a test.")
+            .await
+            .unwrap();
+
+        let config = create_test_config(&docs_path.to_string_lossy(), OutputMode::Merged);
+        let agent = GitHubAgent::new(config);
+
+        let files = agent.generate().await.unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, ".github/copilot-instructions.md");
+
+        // ファイル名のヘッダーが含まれることを確認
+        assert!(files[0].content.contains("# test.md"));
+        // 元のコンテンツが含まれることを確認
+        assert!(files[0].content.contains("# Test Content"));
+        assert!(files[0].content.contains("This is a test."));
+    }
+
+    #[tokio::test]
+    async fn test_generate_split_multiple_files() {
+        let temp_dir = tempdir().unwrap();
+        let docs_path = temp_dir.path();
+
+        // 複数のテスト用ファイルを作成
+        fs::write(docs_path.join("file1.md"), "Content 1")
+            .await
+            .unwrap();
+        fs::write(docs_path.join("file2.md"), "Content 2")
+            .await
+            .unwrap();
+
+        let config = create_test_config(&docs_path.to_string_lossy(), OutputMode::Split);
+        let agent = GitHubAgent::new(config);
+
+        let files = agent.generate().await.unwrap();
+        assert_eq!(files.len(), 2);
+
+        // ファイル名とパスをチェック
+        let paths: Vec<&String> = files.iter().map(|f| &f.path).collect();
+        assert!(paths.contains(&&".github/prompts/file1.md".to_string()));
+        assert!(paths.contains(&&".github/prompts/file2.md".to_string()));
+
+        // 内容をチェック
+        for file in &files {
+            if file.path.contains("file1") {
+                assert!(file.content.contains("Content 1"));
+            } else if file.path.contains("file2") {
+                assert!(file.content.contains("Content 2"));
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_generate_split_with_subdirectory() {
+        let temp_dir = tempdir().unwrap();
+        let docs_path = temp_dir.path();
+
+        // サブディレクトリを作成
+        let sub_dir = docs_path.join("subdir");
+        fs::create_dir(&sub_dir).await.unwrap();
+        fs::write(sub_dir.join("nested.md"), "Nested content")
+            .await
+            .unwrap();
+
+        let config = create_test_config(&docs_path.to_string_lossy(), OutputMode::Split);
+        let agent = GitHubAgent::new(config);
+
+        let files = agent.generate().await.unwrap();
+        assert_eq!(files.len(), 1);
+
+        // パス区切り文字がアンダースコアに変換されていることを確認
+        assert_eq!(files[0].path, ".github/prompts/subdir_nested.md");
+        assert!(files[0].content.contains("Nested content"));
+    }
+
+    #[tokio::test]
+    async fn test_get_merged_output_path() {
+        let config = create_test_config("./docs", OutputMode::Merged);
+        let agent = GitHubAgent::new(config);
+
+        let output_path = agent.get_merged_output_path();
+        assert_eq!(output_path, ".github/copilot-instructions.md");
+    }
+
+    #[tokio::test]
+    async fn test_get_split_prompts_dir() {
+        let config = create_test_config("./docs", OutputMode::Split);
+        let agent = GitHubAgent::new(config);
+
+        let prompts_dir = agent.get_split_prompts_dir();
+        assert_eq!(prompts_dir, ".github/prompts");
+    }
+
+    #[tokio::test]
+    async fn test_prepare_prompts_directory() {
+        let temp_dir = tempdir().unwrap();
+        let prompts_dir = temp_dir.path().join(".github/prompts");
+        let config = create_test_config("./docs", OutputMode::Split);
+        let agent = GitHubAgent::new(config);
+
+        // ディレクトリを作成
+        fs::create_dir_all(&prompts_dir).await.unwrap();
+
+        // 既存のmdファイルを作成
+        let existing_md = prompts_dir.join("old_file.md");
+        let other_file = prompts_dir.join("keep_me.txt");
+        fs::write(&existing_md, "old content").await.unwrap();
+        fs::write(&other_file, "keep this").await.unwrap();
+
+        // ファイルが存在することを確認
+        assert!(existing_md.exists());
+        assert!(other_file.exists());
+
+        // prepare_prompts_directory を実行
+        agent
+            .prepare_prompts_directory(&prompts_dir.to_string_lossy())
+            .await
+            .unwrap();
+
+        // mdファイルは削除され、他のファイルは残っていることを確認
+        assert!(!existing_md.exists());
+        assert!(other_file.exists());
+    }
+
+    #[tokio::test]
+    async fn test_generate_creates_pure_markdown() {
+        let temp_dir = tempdir().unwrap();
+        let docs_path = temp_dir.path();
+
+        // テスト用ファイルを作成
+        fs::write(docs_path.join("test.md"), "# Test\nContent here")
+            .await
+            .unwrap();
+
+        let config = create_test_config(&docs_path.to_string_lossy(), OutputMode::Merged);
+        let agent = GitHubAgent::new(config);
+
+        let files = agent.generate().await.unwrap();
+        let content = &files[0].content;
+
+        // 純粋な Markdown であることを確認（YAML frontmatter なし）
+        assert!(!content.starts_with("---"));
+        assert!(!content.contains("description:"));
+        assert!(!content.contains("alwaysApply:"));
+
+        // 内容は含まれていることを確認
+        assert!(content.contains("# Test"));
+        assert!(content.contains("Content here"));
+    }
+
+    #[tokio::test]
+    async fn test_split_vs_merged_output_paths() {
+        let config_split = create_test_config("./docs", OutputMode::Split);
+        let config_merged = create_test_config("./docs", OutputMode::Merged);
+
+        let agent_split = GitHubAgent::new(config_split);
+        let agent_merged = GitHubAgent::new(config_merged);
+
+        // Split モードとMerged モードで異なるパスを使用することを確認
+        assert_eq!(agent_split.get_split_prompts_dir(), ".github/prompts");
+        assert_eq!(
+            agent_merged.get_merged_output_path(),
+            ".github/copilot-instructions.md"
+        );
+    }
+}

--- a/src/agents/mod.rs
+++ b/src/agents/mod.rs
@@ -6,7 +6,11 @@
 
 pub mod base;
 pub mod claude;
+pub mod cline;
 pub mod cursor;
+pub mod github;
 
 pub use claude::*;
+pub use cline::*;
 pub use cursor::*;
+pub use github::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,9 @@
  */
 
 use aicm::agents::claude::ClaudeAgent;
+use aicm::agents::cline::ClineAgent;
 use aicm::agents::cursor::CursorAgent;
+use aicm::agents::github::GitHubAgent;
 use aicm::config::{error::ConfigError, loader::ConfigLoader};
 use aicm::types::{AIContextConfig, GeneratedFile};
 use anyhow::Result;
@@ -249,6 +251,14 @@ async fn generate_agent_files(
         }
         "claude" => {
             let agent = ClaudeAgent::new(config.clone());
+            agent.generate().await
+        }
+        "github" => {
+            let agent = GitHubAgent::new(config.clone());
+            agent.generate().await
+        }
+        "cline" => {
+            let agent = ClineAgent::new(config.clone());
             agent.generate().await
         }
         _ => Err(anyhow::anyhow!("未対応のエージェント: {}", agent_name)),


### PR DESCRIPTION
GitHub と Cline エージェントを公式ドキュメントに準拠した正しい仕様で実装。Split/Merged モード完全対応。Cline: .clinerules/ (split) または .clinerules (merged)。GitHub: .github/prompts/ (split) または .github/copilot-instructions.md (merged)。17テスト全て通過。