### PR TITLE
Add Rust CI workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,23 @@
+name: Rust CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Rust
+        uses: actions/setup-rust@v1
+        with:
+          rust-version: stable
+          components: clippy,rustfmt
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+      - name: Run clippy
+        run: cargo clippy --all-targets -- -D warnings
+      - name: Run tests
+        run: cargo test --all

--- a/src/config/loader.rs
+++ b/src/config/loader.rs
@@ -140,8 +140,10 @@ agents: not_an_object
 
     #[tokio::test]
     async fn test_validate_config_missing_version() {
-        let mut config = AIContextConfig::default();
-        config.version = "".to_string();
+        let config = AIContextConfig {
+            version: "".to_string(),
+            ..Default::default()
+        };
 
         let result = ConfigLoader::validate_config(&config);
         assert!(result.is_err());
@@ -155,8 +157,10 @@ agents: not_an_object
 
     #[tokio::test]
     async fn test_validate_config_missing_base_docs_dir() {
-        let mut config = AIContextConfig::default();
-        config.base_docs_dir = "".to_string();
+        let config = AIContextConfig {
+            base_docs_dir: "".to_string(),
+            ..Default::default()
+        };
 
         let result = ConfigLoader::validate_config(&config);
         assert!(result.is_err());

--- a/src/types/config.rs
+++ b/src/types/config.rs
@@ -128,7 +128,6 @@ pub struct CursorSplitRule {
     pub manual: Option<bool>,
 }
 
-
 /// Cline エージェント詳細設定
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ClineAgentConfig {
@@ -391,8 +390,10 @@ mod tests {
 
     #[test]
     fn test_effective_output_mode_global_fallback() {
-        let mut config = AIContextConfig::default();
-        config.output_mode = Some(OutputMode::Split);
+        let mut config = AIContextConfig {
+            output_mode: Some(OutputMode::Split),
+            ..Default::default()
+        };
         config.agents.cursor = CursorConfig::Simple(true);
 
         // エージェント個別設定なし → グローバル設定を使用
@@ -404,8 +405,10 @@ mod tests {
 
     #[test]
     fn test_effective_output_mode_agent_override() {
-        let mut config = AIContextConfig::default();
-        config.output_mode = Some(OutputMode::Split);
+        let mut config = AIContextConfig {
+            output_mode: Some(OutputMode::Split),
+            ..Default::default()
+        };
         config.agents.cursor = CursorConfig::Advanced(CursorAgentConfig {
             enabled: true,
             output_mode: Some(OutputMode::Merged),
@@ -421,8 +424,10 @@ mod tests {
 
     #[test]
     fn test_effective_output_mode_claude_always_merged() {
-        let mut config = AIContextConfig::default();
-        config.output_mode = Some(OutputMode::Split);
+        let mut config = AIContextConfig {
+            output_mode: Some(OutputMode::Split),
+            ..Default::default()
+        };
         config.agents.claude = ClaudeConfig::Advanced(ClaudeAgentConfig {
             enabled: true,
             output_mode: Some(OutputMode::Split), // 設定されていても無視される
@@ -485,7 +490,7 @@ mod tests {
 
         assert!(deserialized.is_enabled());
         assert_eq!(deserialized.get_output_mode(), Some(OutputMode::Split));
-        
+
         // split_config: null が出力されないことを確認
         assert!(!yaml.contains("split_config"));
     }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -9,7 +9,7 @@ use std::process::Command;
 #[test]
 fn test_cli_help_command() {
     let output = Command::new("cargo")
-        .args(&["run", "--", "--help"])
+        .args(["run", "--", "--help"])
         .output()
         .expect("Failed to execute command");
 
@@ -24,7 +24,7 @@ fn test_cli_help_command() {
 #[test]
 fn test_cli_version_command() {
     let output = Command::new("cargo")
-        .args(&["run", "--", "--version"])
+        .args(["run", "--", "--version"])
         .output()
         .expect("Failed to execute command");
 


### PR DESCRIPTION
## Summary
- add CI workflow for `cargo fmt`, `clippy`, and `cargo test`
- fix clippy issues in tests

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684623640e308333841647f8f4be266b