### PR TITLE
GitHub Actions でリリース作成を追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,73 @@
+name: Create Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Semantic version"
+        required: true
+        type: string
+
+jobs:
+  create_tag:
+    name: Create tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Git user
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+      - name: Tag and push
+        run: |
+          git tag ${{ github.event.inputs.version }}
+          git push origin ${{ github.event.inputs.version }}
+
+  build:
+    name: Build binaries
+    needs: create_tag
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+      - name: Build release binary
+        run: cargo build --release
+      - name: Package artifact
+        shell: bash
+        run: |
+          mkdir -p dist
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            cp target/release/aicm.exe dist/aicm-${{ runner.os }}.exe
+          else
+            cp target/release/aicm dist/aicm-${{ runner.os }}
+          fi
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: aicm-${{ runner.os }}
+          path: dist/*
+
+  release:
+    name: Publish release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.event.inputs.version }}
+          name: Release ${{ github.event.inputs.version }}
+          files: dist/**/*
+


### PR DESCRIPTION
## Summary
- workflow_dispatch からセマンティックバージョンを受け取り、タグ作成
- 各 OS 向けバイナリをビルド
- 成果物をまとめてリリースに公開

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684a1b838ce483339475ba35d6917de5