### PR TITLE
リリースワークフローのアーキテクチャ検出を改善

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,12 +111,56 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/download-artifact@v4
         with:
           path: dist
+      - name: Generate release notes
+        id: generate_notes
+        run: |
+          echo "Generating release notes..."
+          
+          # Get the latest release tag (excluding the current one)
+          LATEST_TAG=$(git tag -l --sort=-version:refname | grep -v "^${{ github.event.inputs.version }}$" | head -n 1)
+          
+          if [ -z "$LATEST_TAG" ]; then
+            echo "No previous release found, generating notes from first commit"
+            COMPARE_FROM=$(git rev-list --max-parents=0 HEAD)
+          else
+            echo "Latest release: $LATEST_TAG"
+            COMPARE_FROM="$LATEST_TAG"
+          fi
+          
+          # Generate PR list using GitHub CLI
+          RELEASE_NOTES="## What's Changed"$'\n'
+          
+          # Get merged PRs since last release
+          PR_LIST=$(gh pr list --state merged --base main --json number,title,mergedAt,url --jq '.[] | select(.mergedAt > "'$(git log -1 --format=%cI $COMPARE_FROM 2>/dev/null || echo "1970-01-01T00:00:00Z")'") | "- \(.title) #\(.number)"')
+          
+          if [ -n "$PR_LIST" ]; then
+            RELEASE_NOTES="$RELEASE_NOTES"$'\n'"$PR_LIST"
+          else
+            RELEASE_NOTES="$RELEASE_NOTES"$'\n'"- No merged pull requests since last release"
+          fi
+          
+          # Add commit comparison link
+          if [ -n "$LATEST_TAG" ]; then
+            RELEASE_NOTES="$RELEASE_NOTES"$'\n'$'\n'"**Full Changelog**: https://github.com/${{ github.repository }}/compare/$LATEST_TAG...${{ github.event.inputs.version }}"
+          fi
+          
+          # Save to file and environment
+          echo "$RELEASE_NOTES" > release_notes.md
+          echo "RELEASE_NOTES<<EOF" >> $GITHUB_ENV
+          echo "$RELEASE_NOTES" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ github.event.inputs.version }}
           name: Release ${{ github.event.inputs.version }}
+          body: ${{ env.RELEASE_NOTES }}
           files: dist/**/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,15 +93,17 @@ jobs:
         shell: bash
         run: |
           mkdir -p dist
+          ARCH=$(uname -m)
           if [[ "${{ runner.os }}" == "Windows" ]]; then
-            cp target/release/aicm.exe dist/aicm-${{ runner.os }}-${{ runner.arch }}.exe
+            cp target/release/aicm.exe dist/aicm-${{ runner.os }}-${ARCH}.exe
           else
-            cp target/release/aicm dist/aicm-${{ runner.os }}-${{ runner.arch }}
+            cp target/release/aicm dist/aicm-${{ runner.os }}-${ARCH}
           fi
+          echo "ARCH=${ARCH}" >> $GITHUB_ENV
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: aicm-${{ runner.os }}-${{ runner.arch }}
+          name: aicm-${{ runner.os }}-${{ env.ARCH }}
           path: dist/*
 
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,48 +119,77 @@ jobs:
           path: dist
       - name: Generate release notes
         id: generate_notes
-        run: |
-          echo "Generating release notes..."
-          
-          # Get the latest release tag (excluding the current one)
-          LATEST_TAG=$(git tag -l --sort=-version:refname | grep -v "^${{ github.event.inputs.version }}$" | head -n 1)
-          
-          if [ -z "$LATEST_TAG" ]; then
-            echo "No previous release found, generating notes from first commit"
-            COMPARE_FROM=$(git rev-list --max-parents=0 HEAD)
-          else
-            echo "Latest release: $LATEST_TAG"
-            COMPARE_FROM="$LATEST_TAG"
-          fi
-          
-          # Generate PR list using GitHub CLI
-          RELEASE_NOTES="## What's Changed"$'\n'
-          
-          # Get merged PRs since last release
-          PR_LIST=$(gh pr list --state merged --base main --json number,title,mergedAt,url --jq '.[] | select(.mergedAt > "'$(git log -1 --format=%cI $COMPARE_FROM 2>/dev/null || echo "1970-01-01T00:00:00Z")'") | "- \(.title) #\(.number)"')
-          
-          if [ -n "$PR_LIST" ]; then
-            RELEASE_NOTES="$RELEASE_NOTES"$'\n'"$PR_LIST"
-          else
-            RELEASE_NOTES="$RELEASE_NOTES"$'\n'"- No merged pull requests since last release"
-          fi
-          
-          # Add commit comparison link
-          if [ -n "$LATEST_TAG" ]; then
-            RELEASE_NOTES="$RELEASE_NOTES"$'\n'$'\n'"**Full Changelog**: https://github.com/${{ github.repository }}/compare/$LATEST_TAG...${{ github.event.inputs.version }}"
-          fi
-          
-          # Save to file and environment
-          echo "$RELEASE_NOTES" > release_notes.md
-          echo "RELEASE_NOTES<<EOF" >> $GITHUB_ENV
-          echo "$RELEASE_NOTES" >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            console.log('Generating release notes...');
+            
+            // Get all releases to find the previous one
+            const { data: releases } = await github.rest.repos.listReleases({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 100
+            });
+            
+            // Find previous release (excluding current version if it exists)
+            const currentVersion = '${{ github.event.inputs.version }}';
+            const previousRelease = releases.find(release => 
+              release.tag_name !== currentVersion && !release.draft && !release.prerelease
+            );
+            
+            let sinceDate;
+            let compareUrl = '';
+            
+            if (previousRelease) {
+              console.log(`Previous release found: ${previousRelease.tag_name}`);
+              sinceDate = previousRelease.published_at;
+              compareUrl = `\n\n**Full Changelog**: https://github.com/${context.repo.owner}/${context.repo.repo}/compare/${previousRelease.tag_name}...${currentVersion}`;
+            } else {
+              console.log('No previous release found, using repository creation date');
+              const { data: repo } = await github.rest.repos.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo
+              });
+              sinceDate = repo.created_at;
+            }
+            
+            // Get merged PRs since the previous release
+            const { data: pulls } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'closed',
+              base: 'main',
+              sort: 'updated',
+              direction: 'desc',
+              per_page: 100
+            });
+            
+            // Filter PRs that were merged after the previous release
+            const mergedPRs = pulls.filter(pr => 
+              pr.merged_at && 
+              new Date(pr.merged_at) > new Date(sinceDate)
+            );
+            
+            // Generate release notes
+            let releaseNotes = '## What\'s Changed\n';
+            
+            if (mergedPRs.length > 0) {
+              for (const pr of mergedPRs) {
+                releaseNotes += `- ${pr.title} #${pr.number}\n`;
+              }
+            } else {
+              releaseNotes += '- No merged pull requests since last release\n';
+            }
+            
+            releaseNotes += compareUrl;
+            
+            // Set output for next step
+            core.setOutput('release_notes', releaseNotes);
+            console.log('Release notes generated successfully');
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ github.event.inputs.version }}
           name: Release ${{ github.event.inputs.version }}
-          body: ${{ env.RELEASE_NOTES }}
+          body: ${{ steps.generate_notes.outputs.release_notes }}
           files: dist/**/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,17 +93,17 @@ jobs:
         shell: bash
         run: |
           mkdir -p dist
-          ARCH=$(uname -m)
+          TARGET=$(rustc -vV | sed -n 's|host: ||p')
           if [[ "${{ runner.os }}" == "Windows" ]]; then
-            cp target/release/aicm.exe dist/aicm-${{ runner.os }}-${ARCH}.exe
+            cp target/release/aicm.exe dist/aicm-${TARGET}.exe
           else
-            cp target/release/aicm dist/aicm-${{ runner.os }}-${ARCH}
+            cp target/release/aicm dist/aicm-${TARGET}
           fi
-          echo "ARCH=${ARCH}" >> $GITHUB_ENV
+          echo "TARGET=${TARGET}" >> $GITHUB_ENV
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: aicm-${{ runner.os }}-${{ env.ARCH }}
+          name: aicm-${{ env.TARGET }}
           path: dist/*
 
   release:


### PR DESCRIPTION
## Summary
- `${{ runner.arch }}`の代わりに`uname -m`を使用して正確なアーキテクチャ検出を実装
- Apple Silicon Macでは`arm64`、Intel Macでは`x86_64`と正確に表示されるように修正
- 環境変数`ARCH`を使ってartifact名にも正確なアーキテクチャ情報を反映

## Test plan
- [x] リリースワークフローでの正確なアーキテクチャ検出
- [ ] 各OS（macOS、Linux、Windows）でのビルドテスト
- [ ] artifact名の正確性確認

🤖 Generated with [Claude Code](https://claude.ai/code)