### PR TITLE
auto-releaseのバージョン検知をタグベースに改善

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -46,22 +46,24 @@ jobs:
               const currentVersion = currentVersionMatch[1];
               console.log(`Current version: ${currentVersion}`);
               
-              // Get previous version from Cargo.toml
-              let previousVersion = null;
+              // Get previous version from latest git tag
+              let previousVersion = '0.1.0'; // Default if no tags exist
               try {
-                const previousCargoToml = execSync('git show HEAD~1:Cargo.toml', { encoding: 'utf8' });
-                const previousVersionMatch = previousCargoToml.match(/version\s*=\s*"([^"]+)"/);
-                if (previousVersionMatch) {
-                  previousVersion = previousVersionMatch[1];
-                  console.log(`Previous version: ${previousVersion}`);
+                const latestTag = execSync('git describe --tags --abbrev=0 --match="v*" 2>/dev/null', { encoding: 'utf8' }).trim();
+                if (latestTag) {
+                  // Remove 'v' prefix from tag (e.g., 'v0.1.0' -> '0.1.0')
+                  previousVersion = latestTag.replace(/^v/, '');
+                  console.log(`Latest tag version: ${previousVersion}`);
+                } else {
+                  console.log('No existing tags found, using default: 0.1.0');
                 }
               } catch (error) {
-                console.log('Could not get previous version (possibly first commit)');
+                console.log('No existing tags found, using default: 0.1.0');
               }
               
               // Check if version changed
-              const versionChanged = previousVersion && currentVersion !== previousVersion;
-              console.log(`Version changed: ${versionChanged}`);
+              const versionChanged = currentVersion !== previousVersion;
+              console.log(`Version changed: ${versionChanged} (${previousVersion} -> ${currentVersion})`);
               
               require('fs').appendFileSync(process.env.GITHUB_OUTPUT, `version_changed=${versionChanged ? 'true' : 'false'}\n`);
               require('fs').appendFileSync(process.env.GITHUB_OUTPUT, `new_version=${currentVersion}\n`);

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aicm"
-version = "0.1.1"
+version = "0.1.0"
 edition = "2021"
 authors = ["Morooka Akira <morooka.akira@gmail.com>"]
 description = "AI Code Agent Context Management CLI tool for generating context files for multiple AI coding agents"


### PR DESCRIPTION
## Summary
- auto-release.ymlでバージョン比較を前回のCargo.tomlではなく最新のgitタグベースに変更
- タグが存在しない場合のデフォルト値として0.1.0を設定
- より信頼性の高いバージョン変更検知を実現
- テスト準備のためCargo.tomlバージョンを0.1.0に修正

## Changes
- `git describe --tags`を使用して最新のvタグを取得
- タグからvプレフィックスを除去して比較
- デフォルト値0.1.0を設定（初回リリース時対応）
- バージョン変更ログの改善（before -> after形式）
- Cargo.tomlを0.1.0に修正（テスト用ベースライン）

## Test plan
- [x] auto-release.ymlの実装完了
- [x] Cargo.tomlを0.1.0に設定
- [ ] このPRマージ後、Cargo.tomlを0.1.1に変更してタグベース検知をテスト
- [ ] v0.1.1タグが存在しない状態で自動リリースが動作することを確認
- [ ] 次回以降のバージョンアップでタグベース比較が正常動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)