### PR TITLE
バージョン0.1.1リリース - タグベース自動リリースのテスト

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aicm"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Morooka Akira <morooka.akira@gmail.com>"]
 description = "AI Code Agent Context Management CLI tool for generating context files for multiple AI coding agents"


### PR DESCRIPTION
## Summary
Cargo.tomlのバージョンを0.1.1に更新して、改善されたタグベース自動リリース機能をテストします。

## Changes
- `Cargo.toml`のバージョンを`0.1.1`に更新

## Test plan
- [x] バージョン番号の更新
- [ ] このPRをマージ後、auto-release.ymlが自動的にトリガーされることを確認
- [ ] 最新タグ（デフォルト0.1.0）との比較でバージョン変更が検知されることを確認
- [ ] v0.1.1タグが自動作成されることを確認  
- [ ] GitHub Releaseが自動生成されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)