### PR TITLE
Intel Macビルドサポート追加 - マルチアーキテクチャ対応

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,23 @@ jobs:
     needs: create_tag
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          # Linux x86_64
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            artifact_name: aicm-x86_64-unknown-linux-gnu
+          # macOS Apple Silicon (arm64)
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            artifact_name: aicm-aarch64-apple-darwin
+          # macOS Intel (x86_64)
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            artifact_name: aicm-x86_64-apple-darwin
+          # Windows x86_64
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            artifact_name: aicm-x86_64-pc-windows-msvc.exe
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -102,24 +118,23 @@ jobs:
         with:
           toolchain: 1.78.0
           profile: minimal
+          target: ${{ matrix.target }}
       - name: Build release binary
-        run: cargo build --release
+        run: cargo build --release --target ${{ matrix.target }}
       - name: Package artifact
         shell: bash
         run: |
           mkdir -p dist
-          TARGET=$(rustc -vV | sed -n 's|host: ||p')
           if [[ "${{ runner.os }}" == "Windows" ]]; then
-            cp target/release/aicm.exe dist/aicm-${TARGET}.exe
+            cp target/${{ matrix.target }}/release/aicm.exe dist/${{ matrix.artifact_name }}
           else
-            cp target/release/aicm dist/aicm-${TARGET}
+            cp target/${{ matrix.target }}/release/aicm dist/${{ matrix.artifact_name }}
           fi
-          echo "TARGET=${TARGET}" >> $GITHUB_ENV
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: aicm-${{ env.TARGET }}
-          path: dist/*
+          name: ${{ matrix.artifact_name }}
+          path: dist/${{ matrix.artifact_name }}
 
   release:
     name: Publish release


### PR DESCRIPTION
## Summary
GitHub ActionsでIntel Mac（x86_64）とApple Silicon（arm64）両方のビルドをサポートします。

## Changes
- ビルドマトリックスを`include`形式に変更してマルチアーキテクチャ対応
- x86_64-apple-darwinターゲットを追加（Intel Mac用）
- クロスコンパイル対応でtarget指定ビルドに変更
- アーティファクト名にアーキテクチャを明示

## サポートターゲット
| プラットフォーム | ターゲット | アーティファクト名 |
|----------------|-----------|------------------|
| Linux x86_64 | `x86_64-unknown-linux-gnu` | `aicm-x86_64-unknown-linux-gnu` |
| macOS Apple Silicon | `aarch64-apple-darwin` | `aicm-aarch64-apple-darwin` |
| macOS Intel | `x86_64-apple-darwin` | `aicm-x86_64-apple-darwin` |
| Windows x86_64 | `x86_64-pc-windows-msvc` | `aicm-x86_64-pc-windows-msvc.exe` |

## 技術的改善
- **マトリックス最適化**: OSとターゲットの組み合わせを明示的に定義
- **クロスコンパイル**: `cargo build --target`でターゲット指定ビルド
- **明確な命名**: アーティファクト名でアーキテクチャが一目で判別可能
- **効率的ビルド**: 各プラットフォームで最適化されたバイナリを生成

## Test plan
- [x] ビルドマトリックスの追加
- [x] クロスコンパイル対応
- [x] アーティファクト命名の改善
- [ ] Intel Mac環境でのビルド動作確認
- [ ] Apple Silicon環境でのビルド動作確認
- [ ] 各プラットフォームでのバイナリ実行確認

🤖 Generated with [Claude Code](https://claude.ai/code)