### PR TITLE
Rustターゲット追加方法を修正 - クロスコンパイルエラー解消

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,7 +118,8 @@ jobs:
         with:
           toolchain: 1.78.0
           profile: minimal
-          target: ${{ matrix.target }}
+      - name: Add target
+        run: rustup target add ${{ matrix.target }}
       - name: Build release binary
         run: cargo build --release --target ${{ matrix.target }}
       - name: Package artifact


### PR DESCRIPTION
## Summary
GitHub ActionsでのRustクロスコンパイル時のターゲットインストールエラーを修正します。

## 問題
```
error[E0463]: can't find crate for `core`
= note: the `x86_64-apple-darwin` target may not be installed
= help: consider downloading the target with `rustup target add x86_64-apple-darwin`
```

## 原因
`actions-rs/toolchain@v1`の`target`オプションが正常に動作せず、クロスコンパイル用ターゲットがインストールされていない。

## 修正内容
- `actions-rs/toolchain@v1`から`target`オプションを削除
- 明示的に`rustup target add ${{ matrix.target }}`コマンドを追加
- 各マトリックスのターゲットが確実にインストールされるように修正

## 修正前後の比較
```yaml
# Before（動作しない）
- name: Set up Rust
  uses: actions-rs/toolchain@v1
  with:
    toolchain: 1.78.0
    profile: minimal
    target: ${{ matrix.target }}

# After（修正版）
- name: Set up Rust
  uses: actions-rs/toolchain@v1
  with:
    toolchain: 1.78.0
    profile: minimal
- name: Add target
  run: rustup target add ${{ matrix.target }}
```

## 影響するターゲット
- `x86_64-apple-darwin` (Intel Mac)
- `aarch64-apple-darwin` (Apple Silicon Mac)
- `x86_64-unknown-linux-gnu` (Linux)
- `x86_64-pc-windows-msvc` (Windows)

## Test plan
- [x] ターゲット追加方法の修正
- [ ] Intel Mac（x86_64-apple-darwin）ビルドの成功確認
- [ ] Apple Silicon（aarch64-apple-darwin）ビルドの成功確認
- [ ] 他のプラットフォームでのビルド成功確認

🤖 Generated with [Claude Code](https://claude.ai/code)