### PR TITLE
Linux ARM64ビルドサポート追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,10 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             artifact_name: aicm-x86_64-unknown-linux-gnu
+          # Linux ARM64
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            artifact_name: aicm-aarch64-unknown-linux-gnu
           # macOS Apple Silicon (arm64)
           - os: macos-latest
             target: aarch64-apple-darwin
@@ -118,10 +122,17 @@ jobs:
         with:
           toolchain: 1.78.0
           profile: minimal
+      - name: Install cross-compilation dependencies
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
       - name: Add target
         run: rustup target add ${{ matrix.target }}
       - name: Build release binary
         run: cargo build --release --target ${{ matrix.target }}
+        env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
       - name: Package artifact
         shell: bash
         run: |


### PR DESCRIPTION
## Summary
GitHub ActionsでLinux ARM64（aarch64）アーキテクチャのビルドサポートを追加します。

## 追加内容
- `aarch64-unknown-linux-gnu`ターゲットをビルドマトリックスに追加
- クロスコンパイル用の依存関係とツールチェーン設定
- ARM64 Linux環境での実行サポート

## サポートターゲット（更新後）
| プラットフォーム | ターゲット | アーティファクト名 |
|----------------|-----------|------------------|
| Linux x86_64 | `x86_64-unknown-linux-gnu` | `aicm-x86_64-unknown-linux-gnu` |
| **Linux ARM64** | `aarch64-unknown-linux-gnu` | `aicm-aarch64-unknown-linux-gnu` |
| macOS Apple Silicon | `aarch64-apple-darwin` | `aicm-aarch64-apple-darwin` |
| macOS Intel | `x86_64-apple-darwin` | `aicm-x86_64-apple-darwin` |
| Windows x86_64 | `x86_64-pc-windows-msvc` | `aicm-x86_64-pc-windows-msvc.exe` |

## 技術的詳細

### クロスコンパイル設定
```yaml
- name: Install cross-compilation dependencies
  if: matrix.target == 'aarch64-unknown-linux-gnu'
  run: |
    sudo apt-get update
    sudo apt-get install -y gcc-aarch64-linux-gnu

- name: Build release binary
  run: cargo build --release --target ${{ matrix.target }}
  env:
    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
```

## 使用ケース
- **ARM64 Linuxサーバー**: AWS Graviton、Google Cloud T2A等
- **組み込みシステム**: Raspberry Pi 4/5、NVIDIA Jetson等  
- **エッジコンピューティング**: ARM64ベースのエッジデバイス
- **クラウドネイティブ**: ARM64コンテナ環境

## Test plan
- [x] ビルドマトリックスにLinux ARM64ターゲット追加
- [x] クロスコンパイル依存関係の設定
- [x] リンカー設定の追加
- [ ] Ubuntu x86_64環境でのARM64クロスコンパイル動作確認
- [ ] 生成されたARM64バイナリの動作確認
- [ ] 他のプラットフォームビルドへの影響確認

🤖 Generated with [Claude Code](https://claude.ai/code)