### PR TITLE
docs: add Homebrew install instructions to README and README.ja.md

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -34,6 +34,13 @@
 
 ## 🚀 インストール
 
+### Homebrew を使う（macOS/Linux）
+
+```bash
+brew tap morooka-akira/aicm
+brew install aicm
+```
+
 ### Cargo を使用（推奨）
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ A unified CLI tool built in Rust to automatically generate context files for mul
 
 ## 🚀 Installation
 
+### Using Homebrew (macOS/Linux)
+
+```bash
+brew tap morooka-akira/aicm
+brew install aicm
+```
+
 ### Using Cargo (Recommended)
 
 ```bash


### PR DESCRIPTION
Homebrew (brew tap / brew install) によるインストール手順をREADMEおよびREADME.ja.mdに追加しました。