### PR TITLE
feat: add agent-specific base_docs_dir configuration support

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -76,6 +76,11 @@ aicm generate
 # 特定のエージェントのみ生成
 aicm generate --agent cursor
 
+# バージョン確認
+aicm --version
+# または
+aicm -V
+
 # 設定を検証
 aicm validate
 ```
@@ -87,6 +92,7 @@ aicm validate
 | `aicm init`     | -                                                | 現在のディレクトリに設定テンプレートを初期化 |
 | `aicm generate` | `--agent <name>`, `--config <path>`, `-c <path>` | AI エージェント用コンテキストファイルを生成  |
 | `aicm validate` | `--config <path>`, `-c <path>`                   | 設定ファイルの構文と設定を検証               |
+| `aicm --version` | `-V`, `--version`                                | バージョン情報を表示                        |
 
 #### オプション詳細
 
@@ -94,6 +100,7 @@ aicm validate
 | ----------------- | ------ | ------ | -------------------------------------------------------------------------- |
 | `--agent <name>`  | -      | string | 特定のエージェントのみファイル生成（cursor, cline, github, claude, codex） |
 | `--config <path>` | `-c`   | path   | aicm-config.yml の代わりに代替設定ファイルを使用                           |
+| `--version`       | `-V`   | -      | Cargo.toml から現在のバージョンを表示                                     |
 
 ## 📖 設定
 
@@ -131,6 +138,7 @@ agents:
     enabled: true
     output_mode: split
     include_filenames: true
+    base_docs_dir: ./cursor-docs  # エージェント固有のドキュメントディレクトリ
     split_config:
       rules:
         - file_patterns: ["*project*", "*overview*"]
@@ -146,6 +154,7 @@ agents:
   github:
     enabled: true
     output_mode: split
+    base_docs_dir: ./github-docs  # エージェント固有のドキュメントディレクトリ
     split_config:
       rules:
         - file_patterns: ["*backend*", "*api*"]
@@ -184,6 +193,7 @@ aicm generate --agent cursor --config custom.yaml
 | `agents.<name>.enabled`                            | boolean            | -    | `true`           | エージェントの有効/無効                   |
 | `agents.<name>.output_mode`                        | string             | -    | `"split"`        | エージェント固有の出力モード              |
 | `agents.<name>.include_filenames`                  | boolean            | -    | `false`          | エージェント固有のファイル名ヘッダー      |
+| `agents.<name>.base_docs_dir`                      | string             | -    | -                | エージェント固有のドキュメントディレクトリ |
 | `agents.<name>.split_config.rules`                 | list               | -    | -                | ファイル分割ルール設定                    |
 | `agents.<name>.split_config.rules[].file_patterns` | list<string>       | ✓    | `["*project*"]`  | ファイルマッチングパターン（glob）        |
 | `agents.cursor.split_config.rules[].alwaysApply`   | boolean            | -    | `false`          | 常に適用するルール                        |
@@ -196,11 +206,17 @@ aicm generate --agent cursor --config custom.yaml
 
 ```
 your-project/
-├── ai-context/              # ドキュメントディレクトリ（base_docs_dir）
+├── ai-context/              # グローバルドキュメントディレクトリ（base_docs_dir）
 │   ├── 01-project-overview.md
 │   ├── 02-architecture.md
 │   ├── 03-development-rules.md
 │   └── 04-api-reference.md
+├── cursor-docs/             # エージェント固有ドキュメント（cursor.base_docs_dir）
+│   ├── cursor-specific.md
+│   └── cursor-rules.md
+├── github-docs/             # エージェント固有ドキュメント（github.base_docs_dir）
+│   ├── backend-guide.md
+│   └── frontend-guide.md
 ├── aicm-config.yml          # 設定ファイル
 ├── src/
 │   └── main.rs

--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ aicm generate
 # Generate for a specific agent only
 aicm generate --agent cursor
 
+# Check version
+aicm --version
+# or
+aicm -V
+
 # Validate your configuration
 aicm validate
 ```
@@ -87,6 +92,7 @@ aicm validate
 | `aicm init`     | -                                                | Initialize configuration template in current directory |
 | `aicm generate` | `--agent <name>`, `--config <path>`, `-c <path>` | Generate context files for AI agents                   |
 | `aicm validate` | `--config <path>`, `-c <path>`                   | Validate configuration file syntax and settings        |
+| `aicm --version` | `-V`, `--version`                                | Display version information                            |
 
 #### Option Details
 
@@ -94,6 +100,7 @@ aicm validate
 | ----------------- | ----- | ------ | ----------------------------------------------------------------------------- |
 | `--agent <name>`  | -     | string | Generate files for specific agent only (cursor, cline, github, claude, codex) |
 | `--config <path>` | `-c`  | path   | Use alternative configuration file instead of aicm-config.yml                 |
+| `--version`       | `-V`  | -      | Display current version from Cargo.toml                                      |
 
 ## 📖 Configuration
 
@@ -131,6 +138,7 @@ agents:
     enabled: true
     output_mode: split
     include_filenames: true
+    base_docs_dir: ./cursor-docs  # Agent-specific documentation directory
     split_config:
       rules:
         - file_patterns: ["*project*", "*overview*"]
@@ -146,6 +154,7 @@ agents:
   github:
     enabled: true
     output_mode: split
+    base_docs_dir: ./github-docs  # Agent-specific documentation directory
     split_config:
       rules:
         - file_patterns: ["*backend*", "*api*"]
@@ -184,6 +193,7 @@ aicm generate --agent cursor --config custom.yaml
 | `agents.<name>.enabled`                            | boolean            | -        | `true`           | Enable/disable agent                     |
 | `agents.<name>.output_mode`                        | string             | -        | `"split"`        | Agent-specific output mode               |
 | `agents.<name>.include_filenames`                  | boolean            | -        | `false`          | Agent-specific filename headers          |
+| `agents.<name>.base_docs_dir`                      | string             | -        | -                | Agent-specific documentation directory   |
 | `agents.<name>.split_config.rules`                 | list               | -        | -                | File splitting rules configuration       |
 | `agents.<name>.split_config.rules[].file_patterns` | list<string>       | ✓        | `["*project*"]`  | File matching patterns (glob)            |
 | `agents.cursor.split_config.rules[].alwaysApply`   | boolean            | -        | `false`          | Always apply rule                        |
@@ -196,11 +206,17 @@ aicm generate --agent cursor --config custom.yaml
 
 ```
 your-project/
-├── ai-context/              # Documentation directory (base_docs_dir)
+├── ai-context/              # Global documentation directory (base_docs_dir)
 │   ├── 01-project-overview.md
 │   ├── 02-architecture.md
 │   ├── 03-development-rules.md
 │   └── 04-api-reference.md
+├── cursor-docs/             # Agent-specific documentation (cursor.base_docs_dir)
+│   ├── cursor-specific.md
+│   └── cursor-rules.md
+├── github-docs/             # Agent-specific documentation (github.base_docs_dir)
+│   ├── backend-guide.md
+│   └── frontend-guide.md
 ├── aicm-config.yml          # Configuration file
 ├── src/
 │   └── main.rs

--- a/ai-works/2025-06-13-agent-specific-base-docs-dir.md
+++ b/ai-works/2025-06-13-agent-specific-base-docs-dir.md
@@ -1,0 +1,33 @@
+# 2025-06-13 エージェント固有base_docs_dir設定追加作業
+
+## 作業内容
+設定ファイルにエージェント固有の`base_docs_dir`オプションを追加し、各エージェントが独自のドキュメントディレクトリを参照できるようにする。
+
+## 設計方針
+- エージェント設定に`base_docs_dir`フィールドを追加
+- 優先順位: エージェント固有設定 > グローバル設定
+- 既存のコードとの後方互換性を保持
+- 型安全な実装を行う
+
+## 設定例
+```yaml
+version: "1.0"
+output_mode: split
+base_docs_dir: ./ai-context
+agents:
+  cursor:
+    output_mode: split
+    base_docs_dir: ./cursor-context
+  claude: true  # グローバル設定を使用
+```
+
+## 完了要件
+1. エージェント設定構造体に`base_docs_dir`フィールドを追加
+2. `AgentConfigTrait`に`effective_base_docs_dir`メソッドを追加
+3. 各エージェント実装でエージェント固有のディレクトリを使用
+4. テストケースの追加
+5. ドキュメントの更新（README.md、README.ja.md）
+6. -v オプションの説明も追記
+7. 全テスト通過
+8. cargo fmt、cargo clippy通過
+9. PRを作成

--- a/src/agents/claude.rs
+++ b/src/agents/claude.rs
@@ -22,7 +22,11 @@ impl ClaudeAgent {
 
     /// Generate files for Claude (merged mode only)
     pub async fn generate(&self) -> Result<Vec<GeneratedFile>> {
-        let merger = MarkdownMerger::new(self.config.clone());
+        let base_docs_dir = self
+            .config
+            .get_effective_base_docs_dir("claude")
+            .to_string();
+        let merger = MarkdownMerger::new_with_base_dir(self.config.clone(), base_docs_dir);
         self.generate_merged(&merger).await
     }
 

--- a/src/agents/cline.rs
+++ b/src/agents/cline.rs
@@ -38,7 +38,8 @@ impl ClineAgent {
 
     /// Generate files for Cline
     pub async fn generate(&self) -> Result<Vec<GeneratedFile>> {
-        let merger = MarkdownMerger::new(self.config.clone());
+        let base_docs_dir = self.config.get_effective_base_docs_dir("cline").to_string();
+        let merger = MarkdownMerger::new_with_base_dir(self.config.clone(), base_docs_dir);
 
         match self.config.get_effective_output_mode("cline") {
             OutputMode::Merged => self.generate_merged(&merger).await,

--- a/src/agents/codex.rs
+++ b/src/agents/codex.rs
@@ -22,7 +22,8 @@ impl CodexAgent {
 
     /// Generate files for Codex (merged mode only)
     pub async fn generate(&self) -> Result<Vec<GeneratedFile>> {
-        let merger = MarkdownMerger::new(self.config.clone());
+        let base_docs_dir = self.config.get_effective_base_docs_dir("codex").to_string();
+        let merger = MarkdownMerger::new_with_base_dir(self.config.clone(), base_docs_dir);
         self.generate_merged(&merger).await
     }
 

--- a/src/agents/cursor.rs
+++ b/src/agents/cursor.rs
@@ -35,7 +35,11 @@ impl CursorAgent {
 
     /// Generate files for Cursor
     pub async fn generate(&self) -> Result<Vec<GeneratedFile>> {
-        let merger = MarkdownMerger::new(self.config.clone());
+        let base_docs_dir = self
+            .config
+            .get_effective_base_docs_dir("cursor")
+            .to_string();
+        let merger = MarkdownMerger::new_with_base_dir(self.config.clone(), base_docs_dir);
 
         match self.config.get_effective_output_mode("cursor") {
             OutputMode::Merged => self.generate_merged(&merger).await,
@@ -560,6 +564,7 @@ mod tests {
             enabled: true,
             include_filenames: None,
             output_mode: Some(OutputMode::Split),
+            base_docs_dir: None,
             split_config: Some(CursorSplitConfig {
                 rules: vec![CursorSplitRule {
                     file_patterns: vec!["*manual*".to_string()],
@@ -599,6 +604,7 @@ mod tests {
             enabled: true,
             include_filenames: None,
             output_mode: Some(OutputMode::Split),
+            base_docs_dir: None,
             split_config: Some(CursorSplitConfig {
                 rules: vec![CursorSplitRule {
                     file_patterns: vec!["*always*".to_string()],
@@ -637,6 +643,7 @@ mod tests {
             enabled: true,
             include_filenames: None,
             output_mode: Some(OutputMode::Split),
+            base_docs_dir: None,
             split_config: Some(CursorSplitConfig {
                 rules: vec![CursorSplitRule {
                     file_patterns: vec!["*rust*".to_string()],
@@ -675,6 +682,7 @@ mod tests {
             enabled: true,
             include_filenames: None,
             output_mode: Some(OutputMode::Split),
+            base_docs_dir: None,
             split_config: Some(CursorSplitConfig {
                 rules: vec![CursorSplitRule {
                     file_patterns: vec!["*agent*".to_string()],
@@ -715,6 +723,7 @@ mod tests {
             enabled: true,
             include_filenames: None,
             output_mode: Some(OutputMode::Split),
+            base_docs_dir: None,
             split_config: Some(CursorSplitConfig {
                 rules: vec![CursorSplitRule {
                     file_patterns: vec!["*multi*".to_string()],
@@ -753,6 +762,7 @@ mod tests {
             enabled: true,
             include_filenames: None,
             output_mode: Some(OutputMode::Split),
+            base_docs_dir: None,
             split_config: Some(CursorSplitConfig {
                 rules: vec![CursorSplitRule {
                     file_patterns: vec!["matched.md".to_string()],
@@ -819,6 +829,7 @@ mod tests {
             enabled: true,
             include_filenames: None,
             output_mode: Some(OutputMode::Split),
+            base_docs_dir: None,
             split_config: Some(CursorSplitConfig {
                 rules: vec![CursorSplitRule {
                     file_patterns: vec!["*priority*".to_string()],
@@ -856,6 +867,7 @@ mod tests {
             enabled: true,
             include_filenames: None,
             output_mode: Some(OutputMode::Split),
+            base_docs_dir: None,
             split_config: Some(CursorSplitConfig {
                 rules: vec![
                     CursorSplitRule {

--- a/src/agents/github.rs
+++ b/src/agents/github.rs
@@ -40,7 +40,11 @@ impl GitHubAgent {
 
     /// Generate files for GitHub Copilot
     pub async fn generate(&self) -> Result<Vec<GeneratedFile>> {
-        let merger = MarkdownMerger::new(self.config.clone());
+        let base_docs_dir = self
+            .config
+            .get_effective_base_docs_dir("github")
+            .to_string();
+        let merger = MarkdownMerger::new_with_base_dir(self.config.clone(), base_docs_dir);
 
         match self.config.get_effective_output_mode("github") {
             OutputMode::Merged => self.generate_merged(&merger).await,
@@ -499,6 +503,7 @@ mod tests {
             enabled: true,
             include_filenames: None,
             output_mode: Some(OutputMode::Split),
+            base_docs_dir: None,
             split_config: Some(GitHubSplitConfig {
                 rules: vec![
                     GitHubSplitRule {
@@ -619,6 +624,7 @@ mod tests {
             enabled: true,
             include_filenames: None,
             output_mode: Some(OutputMode::Split),
+            base_docs_dir: None,
             split_config: Some(GitHubSplitConfig {
                 rules: vec![
                     GitHubSplitRule {

--- a/src/core/markdown_merger_test.rs
+++ b/src/core/markdown_merger_test.rs
@@ -16,6 +16,7 @@ mod include_filenames_tests {
                 enabled: true,
                 output_mode: Some(OutputMode::Merged),
                 include_filenames: Some(include_filenames),
+                base_docs_dir: None,
             })
         } else {
             ClaudeConfig::Simple(true)

--- a/src/types/config.rs
+++ b/src/types/config.rs
@@ -115,6 +115,9 @@ pub struct CursorAgentConfig {
     /// Whether to include filename headers in merged mode (optional, overrides global setting)
     #[serde(default)]
     pub include_filenames: Option<bool>,
+    /// Base documentation directory (optional, overrides global setting)
+    #[serde(default)]
+    pub base_docs_dir: Option<String>,
     /// Detailed settings for split mode (optional)
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub split_config: Option<CursorSplitConfig>,
@@ -177,6 +180,9 @@ pub struct ClineAgentConfig {
     /// Whether to include filename headers in merged mode (optional, overrides global setting)
     #[serde(default)]
     pub include_filenames: Option<bool>,
+    /// Base documentation directory (optional, overrides global setting)
+    #[serde(default)]
+    pub base_docs_dir: Option<String>,
 }
 
 /// GitHub agent detailed configuration
@@ -191,6 +197,9 @@ pub struct GitHubAgentConfig {
     /// Whether to include filename headers in merged mode (optional, overrides global setting)
     #[serde(default)]
     pub include_filenames: Option<bool>,
+    /// Base documentation directory (optional, overrides global setting)
+    #[serde(default)]
+    pub base_docs_dir: Option<String>,
     /// Detailed settings for split mode (optional)
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub split_config: Option<GitHubSplitConfig>,
@@ -208,6 +217,9 @@ pub struct ClaudeAgentConfig {
     /// Whether to include filename headers in merged mode (optional, overrides global setting)
     #[serde(default)]
     pub include_filenames: Option<bool>,
+    /// Base documentation directory (optional, overrides global setting)
+    #[serde(default)]
+    pub base_docs_dir: Option<String>,
 }
 
 /// Codex agent detailed configuration
@@ -222,6 +234,9 @@ pub struct CodexAgentConfig {
     /// Whether to include filename headers in merged mode (optional, overrides global setting)
     #[serde(default)]
     pub include_filenames: Option<bool>,
+    /// Base documentation directory (optional, overrides global setting)
+    #[serde(default)]
+    pub base_docs_dir: Option<String>,
 }
 
 /// Default value: true
@@ -356,6 +371,44 @@ impl AIContextConfig {
             _ => self.include_filenames.unwrap_or(false),
         }
     }
+
+    /// Get effective base_docs_dir setting for specified agent
+    /// Priority: agent individual setting > global setting
+    pub fn get_effective_base_docs_dir(&self, agent: &str) -> &str {
+        match agent {
+            "cursor" => self
+                .agents
+                .cursor
+                .get_base_docs_dir()
+                .map(|s| s.as_str())
+                .unwrap_or(&self.base_docs_dir),
+            "cline" => self
+                .agents
+                .cline
+                .get_base_docs_dir()
+                .map(|s| s.as_str())
+                .unwrap_or(&self.base_docs_dir),
+            "github" => self
+                .agents
+                .github
+                .get_base_docs_dir()
+                .map(|s| s.as_str())
+                .unwrap_or(&self.base_docs_dir),
+            "claude" => self
+                .agents
+                .claude
+                .get_base_docs_dir()
+                .map(|s| s.as_str())
+                .unwrap_or(&self.base_docs_dir),
+            "codex" => self
+                .agents
+                .codex
+                .get_base_docs_dir()
+                .map(|s| s.as_str())
+                .unwrap_or(&self.base_docs_dir),
+            _ => &self.base_docs_dir,
+        }
+    }
 }
 
 /// Common trait for agent configurations
@@ -366,6 +419,8 @@ pub trait AgentConfigTrait {
     fn get_output_mode(&self) -> Option<OutputMode>;
     /// Get agent individual include_filenames setting
     fn get_include_filenames(&self) -> Option<bool>;
+    /// Get agent individual base_docs_dir setting
+    fn get_base_docs_dir(&self) -> Option<&String>;
 }
 
 impl AgentConfigTrait for CursorConfig {
@@ -387,6 +442,13 @@ impl AgentConfigTrait for CursorConfig {
         match self {
             Self::Simple(_) => None,
             Self::Advanced(config) => config.include_filenames,
+        }
+    }
+
+    fn get_base_docs_dir(&self) -> Option<&String> {
+        match self {
+            Self::Simple(_) => None,
+            Self::Advanced(config) => config.base_docs_dir.as_ref(),
         }
     }
 }
@@ -412,6 +474,13 @@ impl AgentConfigTrait for ClineConfig {
             Self::Advanced(config) => config.include_filenames,
         }
     }
+
+    fn get_base_docs_dir(&self) -> Option<&String> {
+        match self {
+            Self::Simple(_) => None,
+            Self::Advanced(config) => config.base_docs_dir.as_ref(),
+        }
+    }
 }
 
 impl AgentConfigTrait for GitHubConfig {
@@ -433,6 +502,13 @@ impl AgentConfigTrait for GitHubConfig {
         match self {
             Self::Simple(_) => None,
             Self::Advanced(config) => config.include_filenames,
+        }
+    }
+
+    fn get_base_docs_dir(&self) -> Option<&String> {
+        match self {
+            Self::Simple(_) => None,
+            Self::Advanced(config) => config.base_docs_dir.as_ref(),
         }
     }
 }
@@ -468,6 +544,13 @@ impl AgentConfigTrait for ClaudeConfig {
             Self::Advanced(config) => config.include_filenames,
         }
     }
+
+    fn get_base_docs_dir(&self) -> Option<&String> {
+        match self {
+            Self::Simple(_) => None,
+            Self::Advanced(config) => config.base_docs_dir.as_ref(),
+        }
+    }
 }
 
 impl AgentConfigTrait for CodexConfig {
@@ -489,6 +572,13 @@ impl AgentConfigTrait for CodexConfig {
         match self {
             Self::Simple(_) => None,
             Self::Advanced(config) => config.include_filenames,
+        }
+    }
+
+    fn get_base_docs_dir(&self) -> Option<&String> {
+        match self {
+            Self::Simple(_) => None,
+            Self::Advanced(config) => config.base_docs_dir.as_ref(),
         }
     }
 }
@@ -539,12 +629,14 @@ mod tests {
             enabled: true,
             include_filenames: None,
             output_mode: Some(OutputMode::Split),
+            base_docs_dir: None,
             split_config: None,
         });
         config.agents.cline = ClineConfig::Advanced(ClineAgentConfig {
             enabled: false,
             output_mode: Some(OutputMode::Merged),
             include_filenames: None,
+            base_docs_dir: None,
         });
 
         let enabled = config.enabled_agents();
@@ -589,6 +681,7 @@ mod tests {
             enabled: true,
             include_filenames: None,
             output_mode: Some(OutputMode::Merged),
+            base_docs_dir: None,
             split_config: None,
         });
 
@@ -609,6 +702,7 @@ mod tests {
             enabled: true,
             include_filenames: None,
             output_mode: Some(OutputMode::Split), // Set but ignored
+            base_docs_dir: None,
         });
 
         // Claude is always merged
@@ -628,6 +722,7 @@ mod tests {
             enabled: true,
             include_filenames: None,
             output_mode: Some(OutputMode::Split), // Set but ignored
+            base_docs_dir: None,
         });
 
         // Codex is always merged
@@ -680,6 +775,7 @@ mod tests {
             enabled: true,
             include_filenames: None,
             output_mode: Some(OutputMode::Split),
+            base_docs_dir: None,
             split_config: None,
         });
 
@@ -810,5 +906,131 @@ agents:
             config.get_effective_output_mode("claude"),
             OutputMode::Merged
         ); // Always merged
+    }
+
+    #[test]
+    fn test_effective_base_docs_dir_global_fallback() {
+        let config = AIContextConfig {
+            base_docs_dir: "./global-docs".to_string(),
+            ..Default::default()
+        };
+
+        // No agent-specific base_docs_dir, use global setting
+        assert_eq!(
+            config.get_effective_base_docs_dir("cursor"),
+            "./global-docs"
+        );
+        assert_eq!(config.get_effective_base_docs_dir("cline"), "./global-docs");
+        assert_eq!(
+            config.get_effective_base_docs_dir("github"),
+            "./global-docs"
+        );
+        assert_eq!(
+            config.get_effective_base_docs_dir("claude"),
+            "./global-docs"
+        );
+        assert_eq!(config.get_effective_base_docs_dir("codex"), "./global-docs");
+        assert_eq!(
+            config.get_effective_base_docs_dir("unknown"),
+            "./global-docs"
+        );
+    }
+
+    #[test]
+    fn test_effective_base_docs_dir_agent_override() {
+        let mut config = AIContextConfig {
+            base_docs_dir: "./global-docs".to_string(),
+            ..Default::default()
+        };
+
+        // Set agent-specific base_docs_dir
+        config.agents.cursor = CursorConfig::Advanced(CursorAgentConfig {
+            enabled: true,
+            output_mode: None,
+            include_filenames: None,
+            base_docs_dir: Some("./cursor-specific".to_string()),
+            split_config: None,
+        });
+
+        config.agents.cline = ClineConfig::Advanced(ClineAgentConfig {
+            enabled: true,
+            output_mode: None,
+            include_filenames: None,
+            base_docs_dir: Some("./cline-specific".to_string()),
+        });
+
+        // Agent-specific settings override global setting
+        assert_eq!(
+            config.get_effective_base_docs_dir("cursor"),
+            "./cursor-specific"
+        );
+        assert_eq!(
+            config.get_effective_base_docs_dir("cline"),
+            "./cline-specific"
+        );
+
+        // No agent-specific setting, use global
+        assert_eq!(
+            config.get_effective_base_docs_dir("github"),
+            "./global-docs"
+        );
+        assert_eq!(
+            config.get_effective_base_docs_dir("claude"),
+            "./global-docs"
+        );
+        assert_eq!(config.get_effective_base_docs_dir("codex"), "./global-docs");
+    }
+
+    #[test]
+    fn test_agent_specific_base_docs_dir_serialization() {
+        let config = CursorConfig::Advanced(CursorAgentConfig {
+            enabled: true,
+            output_mode: Some(OutputMode::Split),
+            include_filenames: None,
+            base_docs_dir: Some("./custom-docs".to_string()),
+            split_config: None,
+        });
+
+        let yaml = serde_yaml::to_string(&config).unwrap();
+        let deserialized: CursorConfig = serde_yaml::from_str(&yaml).unwrap();
+
+        assert!(deserialized.is_enabled());
+        assert_eq!(deserialized.get_output_mode(), Some(OutputMode::Split));
+        assert_eq!(
+            deserialized.get_base_docs_dir(),
+            Some(&"./custom-docs".to_string())
+        );
+    }
+
+    #[test]
+    fn test_config_with_agent_specific_base_docs_dir_parsing() {
+        let yaml = r#"
+version: "1.0"
+output_mode: split
+base_docs_dir: "./ai-context"
+agents:
+  cursor:
+    output_mode: split
+    base_docs_dir: "./cursor-context"
+  cline:
+    enabled: true
+    base_docs_dir: "./cline-context"
+  github: true
+  claude: true
+"#;
+
+        let config: AIContextConfig = serde_yaml::from_str(yaml).unwrap();
+
+        assert_eq!(config.base_docs_dir, "./ai-context");
+        assert_eq!(
+            config.get_effective_base_docs_dir("cursor"),
+            "./cursor-context"
+        );
+        assert_eq!(
+            config.get_effective_base_docs_dir("cline"),
+            "./cline-context"
+        );
+        assert_eq!(config.get_effective_base_docs_dir("github"), "./ai-context");
+        assert_eq!(config.get_effective_base_docs_dir("claude"), "./ai-context");
     }
 }


### PR DESCRIPTION
## Summary
- エージェント固有の`base_docs_dir`設定を追加
- 各エージェントが独自のドキュメントディレクトリを参照できるよう機能拡張
- `--version`/`-V`フラグのドキュメントも更新

## 主な変更内容

### 🔧 実装
- すべてのエージェント設定構造体に`base_docs_dir`フィールドを追加
- `AIContextConfig`に`get_effective_base_docs_dir`メソッドを実装
- `AgentConfigTrait`に`get_base_docs_dir`メソッドを追加
- `MarkdownMerger`がエージェント固有のディレクトリをサポート
- 全エージェント実装でエージェント固有の`base_docs_dir`を使用

### 📝 設定例
```yaml
version: "1.0"
output_mode: split
base_docs_dir: ./ai-context
agents:
  cursor:
    output_mode: split
    base_docs_dir: ./cursor-context  # Cursorはここのファイルを参照
  claude: true  # グローバル設定を使用
```

### 🧪 テスト
- エージェント固有`base_docs_dir`の動作テストを追加
- 設定の優先順位テスト（エージェント設定 > グローバル設定）
- シリアライゼーション/デシリアライゼーションテスト

### 📚 ドキュメント
- README.md/README.ja.mdに新機能の説明を追加
- `--version`/`-V`フラグの説明も追記
- 設定リファレンステーブルを更新
- プロジェクト構造例を更新

## Test plan
- [x] 全テスト（110個）が通る
- [x] `cargo fmt`、`cargo clippy`が通る
- [x] エージェント固有`base_docs_dir`の動作確認
- [x] 後方互換性の確認
- [x] 設定ファイルのパース確認

🤖 Generated with [Claude Code](https://claude.ai/code)