### PR TITLE
chore: bump version to 0.2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aicm"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["Morooka Akira <morooka.akira@gmail.com>"]
 description = "AI Code Agent Context Management CLI tool for generating context files for multiple AI coding agents"


### PR DESCRIPTION
## Summary

- Update version from 0.2.0 to 0.2.1 in Cargo.toml

## Changes

This version bump includes the recent fix for:
- aicm init template validation issue resolution
- Enhanced YAML parsing error messages with line numbers

🤖 Generated with [Claude Code](https://claude.ai/code)